### PR TITLE
Fixing clang builds

### DIFF
--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -51,6 +51,7 @@ struct aws_s3_vip_connection {
     struct {
 
         /* Linked list node for the owning vip's linked list. */
+        /* Note: this needs to be first for using AWS_CONTAINER_OF with the nested structure. */
         struct aws_linked_list_node vip_node;
 
     } synced_data;
@@ -59,6 +60,7 @@ struct aws_s3_vip_connection {
     struct {
 
         /* Linked list node for a linked list of referencing VIP connections in the below meta request. */
+        /* Note: this needs to be first for using AWS_CONTAINER_OF with the nested structure. */
         struct aws_linked_list_node meta_request_reference_node;
 
         /* Actively processing meta request. */

--- a/include/aws/s3/private/s3_meta_request_impl.h
+++ b/include/aws/s3/private/s3_meta_request_impl.h
@@ -144,6 +144,7 @@ struct aws_s3_meta_request {
     struct {
 
         /* Linked list node for the meta requests linked list in the client. */
+        /* Note: this needs to be first for using AWS_CONTAINER_OF with the nested structure. */
         struct aws_linked_list_node node;
 
         /* List of VIP connections currently processing this meta request. */

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -455,7 +455,7 @@ static void s_s3_client_vip_destroy(struct aws_s3_vip *vip) {
         struct aws_linked_list_node *vip_connection_node = aws_linked_list_pop_back(&vip->vip_connections);
 
         struct aws_s3_vip_connection *vip_connection =
-            AWS_CONTAINER_OF(vip_connection_node, struct aws_s3_vip_connection, synced_data.vip_node);
+            AWS_CONTAINER_OF(vip_connection_node, struct aws_s3_vip_connection, synced_data);
 
         struct aws_s3_client_work *work = s_s3_client_work_new(client, vip_connection);
 
@@ -968,7 +968,7 @@ static void s_s3_client_process_work_task(struct aws_task *task, void *arg, enum
 
         if (&meta_request->threaded_data.node != aws_linked_list_begin(&client->threaded_data.meta_requests)) {
             struct aws_linked_list_node *prev_node = aws_linked_list_prev(&meta_request->threaded_data.node);
-            prev_meta_request = AWS_CONTAINER_OF(prev_node, struct aws_s3_meta_request, threaded_data.node);
+            prev_meta_request = AWS_CONTAINER_OF(prev_node, struct aws_s3_meta_request, threaded_data);
         }
 
         /* Go through all of the VIP connections that this meta request is referenced by, and switch their meta
@@ -978,8 +978,8 @@ static void s_s3_client_process_work_task(struct aws_task *task, void *arg, enum
             struct aws_linked_list_node *ref_vip_connection_node =
                 aws_linked_list_pop_back(&meta_request->threaded_data.referenced_vip_connections);
 
-            struct aws_s3_vip_connection *ref_vip_connection = AWS_CONTAINER_OF(
-                ref_vip_connection_node, struct aws_s3_vip_connection, threaded_data.meta_request_reference_node);
+            struct aws_s3_vip_connection *ref_vip_connection =
+                AWS_CONTAINER_OF(ref_vip_connection_node, struct aws_s3_vip_connection, threaded_data);
 
             /* All VIP connections in this referenced list should be referencing this meta request. */
             AWS_ASSERT(ref_vip_connection->threaded_data.meta_request == meta_request);
@@ -1057,7 +1057,7 @@ static void s_s3_client_process_work_task(struct aws_task *task, void *arg, enum
         }
 
         struct aws_s3_meta_request *next_meta_request =
-            AWS_CONTAINER_OF(next_meta_request_node, struct aws_s3_meta_request, threaded_data.node);
+            AWS_CONTAINER_OF(next_meta_request_node, struct aws_s3_meta_request, threaded_data);
 
         /* Acquire a new reference to this meta request for our VIP connection. */
         aws_s3_meta_request_acquire(next_meta_request);


### PR DESCRIPTION
*Description of changes:*
Fixing use of AWS_CONTAINER_OF when the node structure is nested in a synced or threaded data structure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
