### PR TITLE
Taking out range_end variable

### DIFF
--- a/include/aws/s3/private/s3_part_buffer.h
+++ b/include/aws/s3/private/s3_part_buffer.h
@@ -19,8 +19,6 @@ struct aws_s3_part_buffer {
     /* What part of the overall file transfer this part is currently designated to. */
     uint64_t range_start;
 
-    uint64_t range_end;
-
     /* Re-usable byte buffer. */
     struct aws_byte_buf buffer;
 };

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -36,7 +36,6 @@ typedef void(aws_s3_meta_request_receive_body_callback_fn)(
     struct aws_s3_meta_request *meta_request,
     const struct aws_byte_cursor *body,
     uint64_t range_start,
-    uint64_t range_end,
     void *user_data);
 
 typedef void(aws_s3_meta_request_finish_fn)(

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -592,8 +592,6 @@ struct aws_s3_part_buffer *aws_s3_client_get_part_buffer(struct aws_s3_client *c
             result->range_start = 0;
         }
 
-        result->range_end = result->range_start + client->part_size - 1;
-
         aws_byte_buf_reset(&result->buffer, false);
     }
 

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -911,8 +911,7 @@ static void s_s3_meta_request_process_write_body_task(
     if (meta_request->body_callback != NULL) {
         struct aws_byte_cursor buf_byte_cursor = aws_byte_cursor_from_buf(&part_buffer->buffer);
 
-        meta_request->body_callback(
-            meta_request, &buf_byte_cursor, part_buffer->range_start, part_buffer->range_end, meta_request->user_data);
+        meta_request->body_callback(meta_request, &buf_byte_cursor, part_buffer->range_start, meta_request->user_data);
     }
 
 clean_up:

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -36,15 +36,14 @@ static void s_test_s3_meta_request_body_callback(
     struct aws_s3_meta_request *meta_request,
     const struct aws_byte_cursor *body,
     uint64_t range_start,
-    uint64_t range_end,
     void *user_data) {
     (void)meta_request;
     (void)body;
 
     struct aws_s3_tester_meta_request *tester_meta_request = (struct aws_s3_tester_meta_request *)user_data;
-    tester_meta_request->received_body_size += (range_end - range_start) + 1;
+    tester_meta_request->received_body_size += body->len;
 
-    AWS_LOGF_INFO(AWS_LS_S3_GENERAL, "Received range %" PRIu64 "-%" PRIu64, range_start, range_end);
+    AWS_LOGF_INFO(AWS_LS_S3_GENERAL, "Received range %" PRIu64 "-%" PRIu64, range_start, range_start + body->len - 1);
 }
 
 static void s_test_s3_meta_request_finish(


### PR DESCRIPTION
*Description of changes:*
Taking out range_end variable because it's redundant if you have range_start and a buffer with a length.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
