### PR TITLE
Removing internal options structure

### DIFF
--- a/include/aws/s3/private/s3_meta_request_impl.h
+++ b/include/aws/s3/private/s3_meta_request_impl.h
@@ -102,14 +102,6 @@ struct aws_s3_request {
     } write_body_data;
 };
 
-/* Additional options that can be used internally (ie: by the client) without having to interfere with any user
- * specified options. */
-struct aws_s3_meta_request_internal_options {
-    const struct aws_s3_meta_request_options *options;
-
-    struct aws_s3_client *client;
-};
-
 struct aws_s3_meta_request_vtable {
     bool (*has_work)(const struct aws_s3_meta_request *meta_request);
 
@@ -231,17 +223,20 @@ bool aws_s3_meta_request_has_work(const struct aws_s3_meta_request *meta_request
 /* Creates a new auto-ranged get meta request.  This will do multiple parallel ranged-gets when appropriate. */
 struct aws_s3_meta_request *aws_s3_meta_request_auto_ranged_get_new(
     struct aws_allocator *allocator,
-    const struct aws_s3_meta_request_internal_options *options);
+    struct aws_s3_client *client,
+    const struct aws_s3_meta_request_options *options);
 
 /* Creates a new auto-ranged put meta request.  This will do a multipart upload in parallel when appropriate. */
 struct aws_s3_meta_request *aws_s3_meta_request_auto_ranged_put_new(
     struct aws_allocator *allocator,
-    const struct aws_s3_meta_request_internal_options *options);
+    struct aws_s3_client *client,
+    const struct aws_s3_meta_request_options *options);
 
 /* Creates a new default meta request. This will send the request as is and pass back the response. */
 struct aws_s3_meta_request *aws_s3_meta_request_default_new(
     struct aws_allocator *allocator,
-    const struct aws_s3_meta_request_internal_options *options);
+    struct aws_s3_client *client,
+    const struct aws_s3_meta_request_options *options);
 
 /* Tells the meta request to start sending another request, if there is one currently to send.  This is used by the
  * client.
@@ -257,7 +252,8 @@ void aws_s3_meta_request_send_next_request(
 /* Initialize the base meta request structure. */
 int aws_s3_meta_request_init_base(
     struct aws_allocator *allocator,
-    const struct aws_s3_meta_request_internal_options *options,
+    struct aws_s3_client *client,
+    const struct aws_s3_meta_request_options *options,
     void *impl,
     struct aws_s3_meta_request_vtable *vtable,
     struct aws_s3_meta_request *base_type);

--- a/source/s3_auto_ranged_get.c
+++ b/source/s3_auto_ranged_get.c
@@ -95,11 +95,12 @@ static void s_s3_auto_ranged_get_unlock_synced_data(struct aws_s3_auto_ranged_ge
 /* Allocate a new auto-ranged-get meta request. */
 struct aws_s3_meta_request *aws_s3_meta_request_auto_ranged_get_new(
     struct aws_allocator *allocator,
-    const struct aws_s3_meta_request_internal_options *options) {
+    struct aws_s3_client *client,
+    const struct aws_s3_meta_request_options *options) {
     AWS_PRECONDITION(allocator);
-    AWS_PRECONDITION(options && options->options && options->options->message);
+    AWS_PRECONDITION(options && options->message);
 
-    struct aws_http_headers *initial_message_headers = aws_http_message_get_headers(options->options->message);
+    struct aws_http_headers *initial_message_headers = aws_http_message_get_headers(options->message);
 
     /* TODO If we already have a ranged header, we can break the range up into parts too.  However,
      * this requires some additional logic.  For now just return NULL. */
@@ -107,7 +108,7 @@ struct aws_s3_meta_request *aws_s3_meta_request_auto_ranged_get_new(
         AWS_LOGF_ERROR(
             AWS_LS_S3_META_REQUEST,
             "Could not create Meta Request with message %p. Ranged requests not currently supported.",
-            (void *)options->options->message);
+            (void *)options->message);
         aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
         return NULL;
     }
@@ -117,7 +118,7 @@ struct aws_s3_meta_request *aws_s3_meta_request_auto_ranged_get_new(
 
     /* Try to initialize the base type. */
     if (aws_s3_meta_request_init_base(
-            allocator, options, auto_ranged_get, &s_s3_auto_ranged_get_vtable, &auto_ranged_get->base)) {
+            allocator, client, options, auto_ranged_get, &s_s3_auto_ranged_get_vtable, &auto_ranged_get->base)) {
 
         AWS_LOGF_ERROR(
             AWS_LS_S3_META_REQUEST,

--- a/source/s3_auto_ranged_get.c
+++ b/source/s3_auto_ranged_get.c
@@ -98,7 +98,9 @@ struct aws_s3_meta_request *aws_s3_meta_request_auto_ranged_get_new(
     struct aws_s3_client *client,
     const struct aws_s3_meta_request_options *options) {
     AWS_PRECONDITION(allocator);
-    AWS_PRECONDITION(options && options->message);
+    AWS_PRECONDITION(client);
+    AWS_PRECONDITION(options);
+    AWS_PRECONDITION(options->message);
 
     struct aws_http_headers *initial_message_headers = aws_http_message_get_headers(options->message);
 

--- a/source/s3_auto_ranged_put.c
+++ b/source/s3_auto_ranged_put.c
@@ -108,17 +108,17 @@ static void s_s3_auto_ranged_put_unlock_synced_data(struct aws_s3_auto_ranged_pu
 /* Allocate a new auto-ranged put meta request */
 struct aws_s3_meta_request *aws_s3_meta_request_auto_ranged_put_new(
     struct aws_allocator *allocator,
-    const struct aws_s3_meta_request_internal_options *options) {
-
-    AWS_PRECONDITION(options);
+    struct aws_s3_client *client,
+    const struct aws_s3_meta_request_options *options) {
 
     /* These should already have been validated by the caller. */
-    const struct aws_s3_meta_request_options *meta_request_options = options->options;
-    AWS_PRECONDITION(meta_request_options);
-    AWS_PRECONDITION(meta_request_options->message);
+    AWS_PRECONDITION(allocator);
+    AWS_PRECONDITION(client);
+    AWS_PRECONDITION(options);
+    AWS_PRECONDITION(options->message);
 
     /* We are not guaranteed a body stream from the user at this point, so make sure that we have one. */
-    if (aws_http_message_get_body_stream(meta_request_options->message) == NULL) {
+    if (aws_http_message_get_body_stream(options->message) == NULL) {
         AWS_LOGF_ERROR(AWS_LS_S3_META_REQUEST, "Could not create auto-ranged-put meta request; body stream is NULL.");
         aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
         return NULL;
@@ -128,7 +128,7 @@ struct aws_s3_meta_request *aws_s3_meta_request_auto_ranged_put_new(
         aws_mem_calloc(allocator, 1, sizeof(struct aws_s3_auto_ranged_put));
 
     if (aws_s3_meta_request_init_base(
-            allocator, options, auto_ranged_put, &s_s3_auto_ranged_put_vtable, &auto_ranged_put->base)) {
+            allocator, client, options, auto_ranged_put, &s_s3_auto_ranged_put_vtable, &auto_ranged_put->base)) {
         goto error_clean_up;
     }
 

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -819,19 +819,13 @@ static struct aws_s3_meta_request *s_s3_client_meta_request_factory(
     AWS_PRECONDITION(client);
     AWS_PRECONDITION(options);
 
-    /* TODO just pass in client? */
-    struct aws_s3_meta_request_internal_options internal_options;
-    AWS_ZERO_STRUCT(internal_options);
-    internal_options.options = options;
-    internal_options.client = client;
-
     /* Call the appropriate meta-request new function. */
     if (options->type == AWS_S3_META_REQUEST_TYPE_GET_OBJECT) {
-        return aws_s3_meta_request_auto_ranged_get_new(client->allocator, &internal_options);
+        return aws_s3_meta_request_auto_ranged_get_new(client->allocator, client, options);
     } else if (options->type == AWS_S3_META_REQUEST_TYPE_PUT_OBJECT) {
-        return aws_s3_meta_request_auto_ranged_put_new(client->allocator, &internal_options);
+        return aws_s3_meta_request_auto_ranged_put_new(client->allocator, client, options);
     } else if (options->type == AWS_S3_META_REQUEST_TYPE_DEFAULT) {
-        return aws_s3_meta_request_default_new(client->allocator, &internal_options);
+        return aws_s3_meta_request_default_new(client->allocator, client, options);
     } else {
         AWS_FATAL_ASSERT(false);
     }

--- a/source/s3_default_meta_request.c
+++ b/source/s3_default_meta_request.c
@@ -82,16 +82,23 @@ static void s_s3_meta_request_default_unlock_synced_data(struct aws_s3_meta_requ
 /* Allocate a new default meta request. */
 struct aws_s3_meta_request *aws_s3_meta_request_default_new(
     struct aws_allocator *allocator,
-    const struct aws_s3_meta_request_internal_options *options) {
+    struct aws_s3_client *client,
+    const struct aws_s3_meta_request_options *options) {
     AWS_PRECONDITION(allocator);
-    AWS_PRECONDITION(options && options->options && options->options->message);
+    AWS_PRECONDITION(client);
+    AWS_PRECONDITION(options && options->message);
 
     struct aws_s3_meta_request_default *meta_request_default =
         aws_mem_calloc(allocator, 1, sizeof(struct aws_s3_meta_request_default));
 
     /* Try to initialize the base type. */
     if (aws_s3_meta_request_init_base(
-            allocator, options, meta_request_default, &s_s3_meta_request_default_vtable, &meta_request_default->base)) {
+            allocator,
+            client,
+            options,
+            meta_request_default,
+            &s_s3_meta_request_default_vtable,
+            &meta_request_default->base)) {
 
         AWS_LOGF_ERROR(
             AWS_LS_S3_META_REQUEST,

--- a/source/s3_default_meta_request.c
+++ b/source/s3_default_meta_request.c
@@ -86,7 +86,8 @@ struct aws_s3_meta_request *aws_s3_meta_request_default_new(
     const struct aws_s3_meta_request_options *options) {
     AWS_PRECONDITION(allocator);
     AWS_PRECONDITION(client);
-    AWS_PRECONDITION(options && options->message);
+    AWS_PRECONDITION(options);
+    AWS_PRECONDITION(options->message);
 
     struct aws_s3_meta_request_default *meta_request_default =
         aws_mem_calloc(allocator, 1, sizeof(struct aws_s3_meta_request_default));

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -408,13 +408,10 @@ struct aws_s3_meta_request *aws_s3_tester_meta_request_new(
 
     AWS_ASSERT(client);
 
-    struct aws_s3_meta_request_internal_options internal_options;
-    internal_options.options = &options;
-    internal_options.client = client;
-
     aws_s3_meta_request_init_base(
         tester->allocator,
-        &internal_options,
+        client,
+        &options,
         empty_meta_request,
         &s_s3_empty_meta_request_vtable,
         &empty_meta_request->base);


### PR DESCRIPTION
*Description of changes:*
Removing aws_s3_meta_request_internal_options structure because it is unnecessary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
