### PR TITLE
Moving mutex lock to prevent re-entrant locking

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_test_case(test_s3_put_object_tls_default)
 add_test_case(test_s3_put_object_less_than_part_size)
 add_test_case(test_s3_meta_request_default)
 add_test_case(test_s3_error_response)
+add_test_case(test_s3_existing_host_entry)
 
 set(TEST_BINARY_NAME ${PROJECT_NAME}-tests)
 generate_test_driver(${TEST_BINARY_NAME})

--- a/tests/s3_data_plane_tests.c
+++ b/tests/s3_data_plane_tests.c
@@ -13,6 +13,8 @@
 #include <aws/common/environment.h>
 #include <aws/common/ref_count.h>
 #include <aws/http/request_response.h>
+#include <aws/io/channel_bootstrap.h>
+#include <aws/io/host_resolver.h>
 #include <aws/io/stream.h>
 #include <aws/io/tls_channel_handler.h>
 #include <aws/testing/aws_test_harness.h>
@@ -650,6 +652,86 @@ static int s_test_s3_error_response(struct aws_allocator *allocator, void *ctx) 
     aws_s3_client_release(client);
     client = NULL;
 
+    aws_s3_tester_clean_up(&tester);
+
+    return 0;
+}
+
+static void s_test_s3_existing_host_entry_address_resolved_callback(
+    struct aws_host_resolver *resolver,
+    const struct aws_string *host_name,
+    int err_code,
+    const struct aws_array_list *host_addresses,
+    void *user_data) {
+    (void)resolver;
+    (void)host_name;
+    (void)err_code;
+    (void)host_addresses;
+
+    struct aws_s3_tester *tester = user_data;
+    AWS_ASSERT(tester);
+    aws_condition_variable_notify_one(&tester->signal);
+}
+
+AWS_TEST_CASE(test_s3_existing_host_entry, s_test_s3_existing_host_entry)
+static int s_test_s3_existing_host_entry(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    struct aws_s3_tester tester;
+    AWS_ZERO_STRUCT(tester);
+    ASSERT_SUCCESS(aws_s3_tester_init(allocator, &tester));
+
+    struct aws_s3_client_config client_config;
+    AWS_ZERO_STRUCT(client_config);
+
+    ASSERT_SUCCESS(aws_s3_tester_bind_client(
+        &tester, &client_config, AWS_S3_TESTER_BIND_CLIENT_REGION | AWS_S3_TESTER_BIND_CLIENT_SIGNING));
+
+    struct aws_s3_client *client = aws_s3_client_new(allocator, &client_config);
+
+    struct aws_string *host_name =
+        aws_s3_tester_build_endpoint_string(allocator, &g_test_public_bucket_name, &g_test_s3_region);
+
+    {
+        struct aws_host_resolution_config host_resolver_config;
+        AWS_ZERO_STRUCT(host_resolver_config);
+        host_resolver_config.impl = aws_default_dns_resolve;
+        host_resolver_config.max_ttl = 30;
+        host_resolver_config.impl_data = NULL;
+
+        ASSERT_SUCCESS(aws_host_resolver_resolve_host(
+            client_config.client_bootstrap->host_resolver,
+            host_name,
+            s_test_s3_existing_host_entry_address_resolved_callback,
+            &host_resolver_config,
+            &tester));
+
+        aws_s3_tester_lock_synced_data(&tester);
+        aws_condition_variable_wait(&tester.signal, &tester.synced_data.lock);
+        aws_s3_tester_unlock_synced_data(&tester);
+    }
+
+    /* Put together a simple S3 Get Object request. */
+    struct aws_http_message *message = aws_s3_test_get_object_request_new(
+        allocator, aws_byte_cursor_from_string(host_name), g_s3_path_get_object_test_1MB);
+
+    struct aws_s3_meta_request_options options;
+    AWS_ZERO_STRUCT(options);
+    options.type = AWS_S3_META_REQUEST_TYPE_GET_OBJECT;
+    options.message = message;
+
+    /* Trigger accelerating of our Get Object request. */
+    struct aws_s3_meta_request_test_results meta_request_test_results;
+
+    ASSERT_SUCCESS(aws_s3_tester_send_meta_request(
+        &tester, client, &options, &meta_request_test_results, AWS_S3_TESTER_SEND_META_REQUEST_EXPECT_SUCCESS));
+    ASSERT_SUCCESS(aws_s3_tester_validate_get_object_results(&meta_request_test_results));
+
+    aws_s3_meta_request_test_results_clean_up(&meta_request_test_results);
+
+    aws_http_message_release(message);
+    aws_string_destroy(host_name);
+    aws_s3_client_release(client);
     aws_s3_tester_clean_up(&tester);
 
     return 0;


### PR DESCRIPTION
*Description of changes:*
Avoiding mutex lock around aws_host_resolver_resolve_host to prevent a re-entrant lock if it calls our callback synchronously.  This could happen if the host entry is already present in the host resolver and has already resolve an address.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
