### PR TITLE
Fix undefined reference to aws_s3_init_default_signing_config

### DIFF
--- a/source/s3_util.c
+++ b/source/s3_util.c
@@ -9,6 +9,7 @@
 #include <aws/common/xml_parser.h>
 #include <aws/http/request_response.h>
 #include <aws/s3/s3.h>
+#include <aws/s3/s3_client.h>
 
 const struct aws_byte_cursor g_s3_service_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("s3");
 const struct aws_byte_cursor g_host_header_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("Host");


### PR DESCRIPTION
*Issue:*
When I was using `aws_s3_init_default_signing_config` in C++ SDK, I got an error: _"undefined reference to aws_s3_init_default_signing_config"_ when building everything dynamically.

The root cause is that `aws_s3_init_default_signing_config` is declared in `s3_client.h`
However, in `s3_util.c`, where it's implemented, doesn't include `s3_client.h`

*Description of changes:*
Adding `#include <aws/s3/s3_client.h>` in `s3_util.c`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
