### PR TITLE
Fixing part ordering race condition.

### DIFF
--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -962,11 +962,11 @@ void aws_s3_meta_request_send_request_finish_default(
                 next_streaming_request = aws_s3_meta_request_body_streaming_pop_synced(meta_request);
             }
 
-            aws_s3_meta_request_unlock_synced_data(meta_request);
-
             if (!aws_linked_list_empty(&streaming_requests)) {
                 aws_s3_client_stream_response_body(client, meta_request, &streaming_requests);
             }
+
+            aws_s3_meta_request_unlock_synced_data(meta_request);
         }
 
     } else {

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -54,10 +54,16 @@ static void s_s3_test_meta_request_body_callback(
     struct aws_s3_meta_request_test_results *meta_request_test_results = user_data;
     meta_request_test_results->received_body_size += body->len;
 
+    AWS_LOGF_DEBUG(
+        AWS_LS_S3_GENERAL,
+        "Received range %" PRIu64 "-%" PRIu64 ". Expected range start: %" PRIu64,
+        range_start,
+        range_start + body->len - 1,
+        meta_request_test_results->expected_range_start);
+
+    /* TODO turn this into a test assert when body callback allows returning an error. */
     AWS_ASSERT(meta_request_test_results->expected_range_start == range_start);
     meta_request_test_results->expected_range_start += body->len;
-
-    AWS_LOGF_DEBUG(AWS_LS_S3_GENERAL, "Received range %" PRIu64 "-%" PRIu64, range_start, range_start + body->len - 1);
 }
 
 static void s_s3_test_meta_request_finish(


### PR DESCRIPTION
*Description of changes:*
Fixing part ordering race condition where two sets of requests that finish close together could schedule their body streaming tasks out of order.  This was causing an occasional test failure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
