### PR TITLE
Fixing up client clean-up flow/small improvements

### DIFF
--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -26,7 +26,6 @@ typedef void(aws_s3_client_get_http_connection_callback)(
 
 typedef void(aws_s3_client_sign_callback)(int error_code, void *user_data);
 
-
 typedef void(aws_s3_vip_shutdown_callback_fn)(void *user_data);
 
 /* Represents one Virtual IP (VIP) in S3, including a connection manager that points directly at that VIP. */
@@ -45,12 +44,15 @@ struct aws_s3_vip {
     /* Address this VIP represents. */
     struct aws_string *host_address;
 
+    /* Callback used when this vip has completely shutdown, which happens when all associated connections and the
+     * connection manager are shutdown. */
     aws_s3_vip_shutdown_callback_fn *shutdown_callback;
 
+    /* User data for the shutdown callback. */
     void *shutdown_user_data;
 
     struct {
-        /* How many vip connections are allocated */
+        /* How many vip connections are allocated for this vip. */
         uint32_t num_vip_connections;
 
         /* Whether or not the connection manager is allocated. If the connection manager is NULL, but this is true, the
@@ -204,8 +206,10 @@ struct aws_s3_client {
         /* Client list of on going meta requests. */
         struct aws_linked_list meta_requests;
 
+        /* Next meta request that the work_task will start with on its next update. */
         struct aws_s3_meta_request *next_meta_request;
 
+        /* Number of requests being processed, either still being sent/received or being streamed to the caller. */
         uint32_t num_requests_in_flight;
 
     } threaded_data;

--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -52,7 +52,8 @@ struct aws_s3_vip {
     void *shutdown_user_data;
 
     struct {
-        /* How many vip connections are allocated for this vip. */
+        /* How many aws_s3_vip_connection structures are allocated for this vip. This structure will not finish cleaning
+         * up until this counter is 0.*/
         uint32_t num_vip_connections;
 
         /* Whether or not the connection manager is allocated. If the connection manager is NULL, but this is true, the

--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -30,20 +30,26 @@ typedef void(aws_s3_client_sign_callback)(int error_code, void *user_data);
 struct aws_s3_vip {
     struct aws_linked_list_node node;
 
-    /* True if this VIP is currently being cleaned up.  The work event loop will check for this flag and clean up
-     * related VIP connections. */
+    /* True if this VIP is in use. */
     struct aws_atomic_var active;
-
-    struct aws_ref_count internal_ref_count;
 
     /* S3 Client that owns this vip. */
     struct aws_s3_client *owning_client;
 
+    /* Connection manager shared by all VIP connections. */
+    struct aws_http_connection_manager *http_connection_manager;
+
     /* Address this VIP represents. */
     struct aws_string *host_address;
 
-    /* Connection manager shared by all VIP connections. */
-    struct aws_http_connection_manager *http_connection_manager;
+    struct {
+        /* How many vip connections are allocated */
+        uint32_t num_vip_connections;
+
+        /* Whether or not the connection manager is allocated. If the connection manager is NULL, but this is true, the
+         * shutdown callback for the connection manager has not yet been called. */
+        uint32_t http_connection_manager_active;
+    } synced_data;
 };
 
 /* Represents one connection on a particular VIP. */
@@ -90,12 +96,6 @@ struct aws_s3_client {
 
     struct aws_ref_count ref_count;
 
-    /* Internal ref count is used for tracking the lifetime of resources owned by the client that have asynchronous
-     * clean up.  In those cases, we don't want to prevent clean up from being initiated (which is what would happen
-     * with a normal reference), but we do want to know when we can completely clean up (ie: regular ref count and
-     * internal ref count are both 0). */
-    struct aws_ref_count internal_ref_count;
-
     /* Client bootstrap for setting up connection managers. */
     struct aws_client_bootstrap *client_bootstrap;
 
@@ -141,7 +141,11 @@ struct aws_s3_client {
         /* Endpoint to use for the bucket. */
         struct aws_string *endpoint;
 
-        uint32_t vip_count;
+        /* How many vips are being actively used. */
+        uint32_t active_vip_count;
+
+        /* How many vips are allocated. (This number includes vips that are in the process of cleaning up) */
+        uint32_t allocated_vip_count;
 
         /* Linked list of active VIP's. */
         struct aws_linked_list vips;
@@ -161,11 +165,25 @@ struct aws_s3_client {
         /* Host listener to get new IP addresses. */
         struct aws_host_listener *host_listener;
 
+        /* Whether or not the client has started cleaning up all of its resources */
+        uint32_t active : 1;
+
         /* Whether or not work processing is currently scheduled. */
         uint32_t process_work_task_scheduled : 1;
 
-        /* Whether or not the client has started cleaning up all of its resources */
-        uint32_t active : 1;
+        /* Whether or not work process is currently in progress. */
+        uint32_t process_work_task_in_progress : 1;
+
+        /* Whether or not the body streaming ELG is allocated. If the body streaming ELG is NULL, but this is true, the
+         * shutdown callback has not yet been called.*/
+        uint32_t body_streaming_elg_allocated : 1;
+
+        /* Whether or not the host listener is allocated. If the host listener is NULL, but this is true, the shutdown
+         * callback for the listener has not yet been called. */
+        uint32_t host_listener_allocated : 1;
+
+        /* True if client has been flagged to finish destroying itself. Used to catch double-destroy bugs.*/
+        uint32_t finish_destroy : 1;
 
         /* True if the host resolver couldn't find the endpoint.*/
         uint32_t invalid_endpoint : 1;

--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -26,6 +26,9 @@ typedef void(aws_s3_client_get_http_connection_callback)(
 
 typedef void(aws_s3_client_sign_callback)(int error_code, void *user_data);
 
+
+typedef void(aws_s3_vip_shutdown_callback_fn)(void *user_data);
+
 /* Represents one Virtual IP (VIP) in S3, including a connection manager that points directly at that VIP. */
 struct aws_s3_vip {
     struct aws_linked_list_node node;
@@ -41,6 +44,10 @@ struct aws_s3_vip {
 
     /* Address this VIP represents. */
     struct aws_string *host_address;
+
+    aws_s3_vip_shutdown_callback_fn *shutdown_callback;
+
+    void *shutdown_user_data;
 
     struct {
         /* How many vip connections are allocated */
@@ -220,5 +227,28 @@ void aws_s3_client_stream_response_body(
     struct aws_s3_client *client,
     struct aws_s3_meta_request *meta_request,
     struct aws_linked_list *requests);
+
+AWS_EXTERN_C_BEGIN
+
+AWS_S3_API
+struct aws_s3_vip *aws_s3_vip_new(
+    struct aws_s3_client *client,
+    const struct aws_byte_cursor *host_address,
+    const struct aws_byte_cursor *server_name,
+    uint32_t num_vip_connections,
+    struct aws_linked_list *out_vip_connections_list,
+    aws_s3_vip_shutdown_callback_fn *shutdown_callback,
+    void *shutdown_user_data);
+
+AWS_S3_API
+void aws_s3_vip_start_destroy(struct aws_s3_vip *vip);
+
+AWS_S3_API
+struct aws_s3_vip *aws_s3_find_vip(const struct aws_linked_list *vip_list, const struct aws_byte_cursor *host_address);
+
+AWS_S3_API
+void aws_s3_vip_connection_destroy(struct aws_s3_client *client, struct aws_s3_vip_connection *vip_connection);
+
+AWS_EXTERN_C_END
 
 #endif /* AWS_S3_CLIENT_IMPL_H */

--- a/include/aws/s3/private/s3_meta_request_impl.h
+++ b/include/aws/s3/private/s3_meta_request_impl.h
@@ -173,12 +173,6 @@ struct aws_s3_meta_request {
 
     struct aws_ref_count ref_count;
 
-    /* Internal reference count.  This does not keep the meta request alive, but does delay the finish callback from
-     * taking place. Like a normal reference count, this should be incremented from a place that already owns an
-     * internal ref count.
-     */
-    struct aws_ref_count internal_ref_count;
-
     void *impl;
 
     struct aws_s3_meta_request_vtable *vtable;
@@ -321,10 +315,6 @@ void aws_s3_meta_request_finish(
     struct aws_s3_request *failed_request,
     int response_status,
     int error_code);
-
-void aws_s3_meta_request_internal_acquire(struct aws_s3_meta_request *meta_request);
-
-void aws_s3_meta_request_internal_release(struct aws_s3_meta_request *meta_request);
 
 AWS_S3_API
 void aws_s3_meta_request_lock_synced_data(struct aws_s3_meta_request *meta_request);

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -61,23 +61,42 @@ AWS_STATIC_STRING_FROM_LITERAL(s_http_proxy_env_var, "HTTP_PROXY");
 static void s_s3_client_lock_synced_data(struct aws_s3_client *client);
 static void s_s3_client_unlock_synced_data(struct aws_s3_client *client);
 
+/* Called when ref count is 0. */
 static void s_s3_client_start_destroy(void *user_data);
+
+typedef void(s3_client_update_synced_data_state_fn)(struct aws_s3_client *client);
+
+/* Used to atomically update client state during clean-up and check for finishing destruction. */
+static void s_s3_client_check_for_shutdown(
+    struct aws_s3_client *client,
+    s3_client_update_synced_data_state_fn *update_fn);
+
+/* Called when the body streaming elg shutdown has completed. */
 static void s_s3_client_finish_destroy(void *user_data);
 
-/* Interfaces with "internal" reference count.  For more info, see the comments by the internal_ref_count variable in
- * the header. */
-static void s_s3_client_internal_acquire(struct aws_s3_client *client);
-static void s_s3_client_internal_release(struct aws_s3_client *client);
+static void s_s3_client_body_streaming_elg_shutdown(void *user_data);
+
+/* Initializes/cleans-up a vip structure. */
+static struct aws_s3_vip *s_s3_client_vip_new_synced(
+    struct aws_s3_client *client,
+    const struct aws_byte_cursor *host_address,
+    const struct aws_byte_cursor *server_name);
+
+static void s_s3_client_vip_destroy(struct aws_s3_vip *vip);
+
+typedef void(s3_client_vip_update_synced_data_state_fn)(struct aws_s3_vip *vip);
 
 static void s_s3_client_vip_http_connection_manager_shutdown_callback(void *user_data);
 
-/* Initializes/cleans up a VIP structure.  Both assume the lock is already held.  */
-static struct aws_s3_vip *s_s3_client_vip_new(struct aws_s3_client *client, const struct aws_byte_cursor *host_address);
-static void s_s3_client_vip_destroy(struct aws_s3_vip *vip);
+/* Used to atomically update vip state during clean-up and check for finishing shutdown. */
+static void s_s3_client_vip_check_for_shutdown(
+    struct aws_s3_vip *vip,
+    s3_client_vip_update_synced_data_state_fn *update_fn);
+
 static void s_s3_client_vip_finish_destroy(void *user_data);
 
 /* Allocates/Destroy a VIP Connection structure. */
-struct aws_s3_vip_connection *aws_s3_vip_connection_new(struct aws_s3_client *client, struct aws_s3_vip *vip);
+struct aws_s3_vip_connection *aws_s3_vip_connection_new_synced(struct aws_s3_client *client, struct aws_s3_vip *vip);
 void s_s3_vip_connection_destroy(struct aws_s3_client *client, struct aws_s3_vip_connection *vip_connection);
 
 static struct aws_s3_vip *s_s3_find_vip(
@@ -176,8 +195,6 @@ struct aws_s3_client *aws_s3_client_new(
     client->vtable = &s_s3_client_default_vtable;
 
     aws_ref_count_init(&client->ref_count, client, (aws_simple_completion_callback *)s_s3_client_start_destroy);
-    aws_ref_count_init(
-        &client->internal_ref_count, client, (aws_simple_completion_callback *)s_s3_client_finish_destroy);
 
     /* Store our client bootstrap. */
     client->client_bootstrap = client_config->client_bootstrap;
@@ -188,15 +205,25 @@ struct aws_s3_client *aws_s3_client_new(
 
     client->process_work_event_loop = aws_event_loop_group_get_next_loop(event_loop_group);
 
-    uint16_t num_event_loops =
-        (uint16_t)aws_array_list_length(&client->client_bootstrap->event_loop_group->event_loops);
-    uint16_t num_streaming_threads = num_event_loops / 2;
+    /* Set up body streaming ELG */
+    {
+        uint16_t num_event_loops =
+            (uint16_t)aws_array_list_length(&client->client_bootstrap->event_loop_group->event_loops);
+        uint16_t num_streaming_threads = num_event_loops / 2;
 
-    if (num_streaming_threads < 1) {
-        num_streaming_threads = 1;
+        if (num_streaming_threads < 1) {
+            num_streaming_threads = 1;
+        }
+
+        struct aws_shutdown_callback_options body_streaming_elg_shutdown_options = {
+            .shutdown_callback_fn = s_s3_client_body_streaming_elg_shutdown,
+            .shutdown_callback_user_data = client,
+        };
+
+        client->body_streaming_elg = aws_event_loop_group_new_default(
+            client->allocator, num_streaming_threads, &body_streaming_elg_shutdown_options);
+        client->synced_data.body_streaming_elg_allocated = true;
     }
-
-    client->body_streaming_elg = aws_event_loop_group_new_default(client->allocator, num_streaming_threads, NULL);
 
     /* Make a copy of the region string. */
     client->region = aws_string_new_from_array(allocator, client_config->region.ptr, client_config->region.len);
@@ -338,10 +365,6 @@ static void s_s3_client_get_http_connection(
     AWS_PRECONDITION(client->vtable);
     AWS_PRECONDITION(client->vtable->get_http_connection);
 
-    /* Acquire internal ref to keep client from cleaning up until the s_s3_client_on_acquire_http_connection callback is
-     * made. */
-    s_s3_client_internal_acquire(client);
-
     client->vtable->get_http_connection(client, vip_connection, s_s3_client_on_acquire_http_connection);
 }
 
@@ -352,21 +375,27 @@ static void s_s3_client_start_destroy(void *user_data) {
     struct aws_linked_list local_vip_list;
     aws_linked_list_init(&local_vip_list);
 
+    struct aws_host_listener *host_listener = NULL;
+
     s_s3_client_lock_synced_data(client);
 
+    AWS_ASSERT(client->synced_data.active);
     client->synced_data.active = false;
 
-    if (client->synced_data.host_listener != NULL) {
-        aws_host_resolver_remove_host_listener(
-            client->client_bootstrap->host_resolver, client->synced_data.host_listener);
-        client->synced_data.host_listener = NULL;
-    }
+    /* Grab the host listener from the synced_data so that we can remove it outside of the lock. */
+    host_listener = client->synced_data.host_listener;
+    client->synced_data.host_listener = NULL;
 
     /* Swap out all VIP's so that we can clean them up outside of the lock. */
     aws_linked_list_swap_contents(&local_vip_list, &client->synced_data.vips);
-    client->synced_data.vip_count = 0;
+    client->synced_data.active_vip_count = 0;
 
     s_s3_client_unlock_synced_data(client);
+
+    if (host_listener != NULL) {
+        aws_host_resolver_remove_host_listener(client->client_bootstrap->host_resolver, host_listener);
+        host_listener = NULL;
+    }
 
     /* Iterate through the local list, removing each VIP. */
     while (!aws_linked_list_empty(&local_vip_list)) {
@@ -378,27 +407,44 @@ static void s_s3_client_start_destroy(void *user_data) {
         vip = NULL;
     }
 
-    /* Release the initial internal ref count that we have held since allocation. */
-    s_s3_client_internal_release(client);
+    aws_event_loop_group_release(client->body_streaming_elg);
+    client->body_streaming_elg = NULL;
 }
 
-static void s_s3_client_internal_acquire(struct aws_s3_client *client) {
-    AWS_PRECONDITION(client);
+static void s_s3_client_check_for_shutdown(
+    struct aws_s3_client *client,
+    s3_client_update_synced_data_state_fn *update_fn) {
+    (void)client;
 
-    aws_ref_count_acquire(&client->internal_ref_count);
+    bool finish_destroy = false;
+
+    s_s3_client_lock_synced_data(client);
+
+    if (update_fn != NULL) {
+        update_fn(client);
+    }
+
+    /* We shouldn't ever trip this twice. If we did, that means we potentially would have a double free.*/
+    AWS_ASSERT(!client->synced_data.finish_destroy);
+
+    finish_destroy = client->synced_data.active == false && client->synced_data.allocated_vip_count == 0 &&
+                     client->synced_data.host_listener_allocated == false &&
+                     client->synced_data.body_streaming_elg_allocated == false &&
+                     client->synced_data.process_work_task_scheduled == false &&
+                     client->synced_data.process_work_task_in_progress == false;
+
+    client->synced_data.finish_destroy = finish_destroy;
+
+    s_s3_client_unlock_synced_data(client);
+
+    if (finish_destroy) {
+        s_s3_client_finish_destroy(client);
+    }
 }
 
-static void s_s3_client_internal_release(struct aws_s3_client *client) {
-    AWS_PRECONDITION(client);
-
-    aws_ref_count_release(&client->internal_ref_count);
-}
-
-/* Called once all internal references have been released. */
 static void s_s3_client_finish_destroy(void *user_data) {
-
+    AWS_PRECONDITION(user_data);
     struct aws_s3_client *client = user_data;
-    AWS_PRECONDITION(client);
 
     aws_string_destroy(client->region);
     client->region = NULL;
@@ -422,7 +468,6 @@ static void s_s3_client_finish_destroy(void *user_data) {
 
     aws_retry_strategy_release(client->retry_strategy);
 
-    aws_event_loop_group_release(client->body_streaming_elg);
     aws_event_loop_group_release(client->client_bootstrap->event_loop_group);
 
     aws_client_bootstrap_release(client->client_bootstrap);
@@ -441,13 +486,39 @@ static void s_s3_client_finish_destroy(void *user_data) {
     }
 }
 
+static void s_s3_client_vip_set_conn_manager_shutdown(struct aws_s3_vip *vip) {
+    AWS_PRECONDITION(vip);
+    AWS_PRECONDITION(vip->owning_client);
+    ASSERT_SYNCED_DATA_LOCK_HELD(vip->owning_client);
+    vip->synced_data.http_connection_manager_active = false;
+}
+
 static void s_s3_client_vip_http_connection_manager_shutdown_callback(void *user_data) {
     AWS_PRECONDITION(user_data);
 
+    struct aws_s3_vip *vip = user_data;
+    AWS_PRECONDITION(vip);
+
+    AWS_LOGF_DEBUG(
+        AWS_LS_S3_CLIENT, "id=%p VIP %p Connection manager shutdown", (void *)vip->owning_client, (void *)vip);
+
+    s_s3_client_vip_check_for_shutdown(vip, s_s3_client_vip_set_conn_manager_shutdown);
+}
+
+static void s_s3_client_set_body_streaming_elg_shutdown_synced(struct aws_s3_client *client) {
+    AWS_PRECONDITION(client);
+    ASSERT_SYNCED_DATA_LOCK_HELD(client);
+
+    AWS_LOGF_DEBUG(AWS_LS_S3_CLIENT, "id=%p Client body streaming ELG shutdown.", (void *)client);
+
+    client->synced_data.body_streaming_elg_allocated = false;
+}
+
+static void s_s3_client_body_streaming_elg_shutdown(void *user_data) {
     struct aws_s3_client *client = user_data;
     AWS_PRECONDITION(client);
 
-    s_s3_client_internal_release(client);
+    s_s3_client_check_for_shutdown(client, s_s3_client_set_body_streaming_elg_shutdown_synced);
 }
 
 static int s_s3_client_get_proxy_uri(struct aws_s3_client *client, struct aws_uri *proxy_uri) {
@@ -501,17 +572,15 @@ clean_up:
 }
 
 /* Initialize a new VIP structure for the client to use, given an address. Assumes lock is held. */
-static struct aws_s3_vip *s_s3_client_vip_new(
+static struct aws_s3_vip *s_s3_client_vip_new_synced(
     struct aws_s3_client *client,
-    const struct aws_byte_cursor *host_address) {
+    const struct aws_byte_cursor *host_address,
+    const struct aws_byte_cursor *server_name) {
+    ASSERT_SYNCED_DATA_LOCK_HELD(client);
     AWS_PRECONDITION(client);
 
     struct aws_s3_vip *vip = aws_mem_calloc(client->allocator, 1, sizeof(struct aws_s3_vip));
-
-    aws_ref_count_init(&vip->internal_ref_count, vip, s_s3_client_vip_finish_destroy);
-
     vip->owning_client = client;
-    s_s3_client_internal_acquire(client);
 
     /* Copy over the host address. */
     vip->host_address = aws_string_new_from_array(client->allocator, host_address->ptr, host_address->len);
@@ -531,7 +600,7 @@ static struct aws_s3_vip *s_s3_client_vip_new(
     manager_options.host = aws_byte_cursor_from_string(vip->host_address);
     manager_options.max_connections = s_num_connections_per_vip;
     manager_options.shutdown_complete_callback = s_s3_client_vip_http_connection_manager_shutdown_callback;
-    manager_options.shutdown_complete_user_data = client;
+    manager_options.shutdown_complete_user_data = vip;
 
     struct aws_uri proxy_uri;
     AWS_ZERO_STRUCT(proxy_uri);
@@ -557,14 +626,8 @@ static struct aws_s3_vip *s_s3_client_vip_new(
             manager_tls_options->server_name = NULL;
         }
 
-        /*
-         * TODO: this should come via function parameter as part of the callback once multiple endpoints are
-         * supported
-         *
-         * synced data lock currently held by the only caller of this
-         */
-        struct aws_byte_cursor server_name = aws_byte_cursor_from_string(client->synced_data.endpoint);
-        aws_tls_connection_options_set_server_name(manager_tls_options, client->allocator, &server_name);
+        aws_tls_connection_options_set_server_name(
+            manager_tls_options, client->allocator, (struct aws_byte_cursor *)server_name);
 
         manager_options.tls_connection_options = manager_tls_options;
         manager_options.port = s_https_port;
@@ -573,6 +636,14 @@ static struct aws_s3_vip *s_s3_client_vip_new(
     }
 
     vip->http_connection_manager = aws_http_connection_manager_new(client->allocator, &manager_options);
+    vip->synced_data.http_connection_manager_active = true;
+
+    AWS_LOGF_DEBUG(
+        AWS_LS_S3_CLIENT,
+        "id=%p: Created connection manager %p for VIP %p",
+        (void *)client,
+        (void *)vip->http_connection_manager,
+        (void *)vip);
 
     if (manager_tls_options != NULL) {
         aws_tls_connection_options_clean_up(manager_tls_options);
@@ -600,9 +671,8 @@ static struct aws_s3_vip *s_s3_client_vip_new(
 
     aws_atomic_init_int(&vip->active, 1);
 
-    /* Acquire internal reference for the HTTP Connection Manager. */
-    s_s3_client_internal_acquire(client);
-
+    ++client->synced_data.allocated_vip_count;
+    ++client->synced_data.active_vip_count;
     return vip;
 
 error_clean_up:
@@ -623,21 +693,76 @@ static void s_s3_client_vip_destroy(struct aws_s3_vip *vip) {
 
     struct aws_s3_client *client = vip->owning_client;
     s_s3_client_lock_synced_data(client);
-    --client->synced_data.vip_count;
+
+    /* This vip is no longer being used, so subtract from active count so that another one can take its place. */
+    --client->synced_data.active_vip_count;
     s_s3_client_schedule_process_work_task_synced(client);
     s_s3_client_unlock_synced_data(client);
+}
 
-    aws_ref_count_release(&vip->internal_ref_count);
-    vip = NULL;
+static void s_s3_client_vip_check_for_shutdown(
+    struct aws_s3_vip *vip,
+    s3_client_vip_update_synced_data_state_fn *update_fn) {
+    AWS_PRECONDITION(vip);
+    AWS_PRECONDITION(vip->owning_client);
+
+    bool finish_destroy = false;
+    struct aws_http_connection_manager *conn_manager = NULL;
+
+    s_s3_client_lock_synced_data(vip->owning_client);
+
+    if (update_fn != NULL) {
+        update_fn(vip);
+    }
+
+    /* If this vip is active, we are not cleaning up. */
+    if (aws_atomic_load_int(&vip->active) == 1) {
+        goto unlock;
+    }
+
+    /* If this vip still has connections, we are not done cleaning up. */
+    if (vip->synced_data.num_vip_connections > 0) {
+        goto unlock;
+    }
+
+    /* If the connection manager is active, then we can try initating a clean up of it now. */
+    if (vip->synced_data.http_connection_manager_active) {
+
+        /* If the connection manager is not NULL, take the pointer from the synced data so that it we can clean it up
+         * outside of the lock. We reset the pointer on the synced_data so that nothing else entering this function will
+         * trigger a double release. */
+        if (vip->http_connection_manager != NULL) {
+            conn_manager = vip->http_connection_manager;
+            vip->http_connection_manager = NULL;
+        }
+
+        goto unlock;
+    }
+
+    finish_destroy = true;
+
+unlock:
+    s_s3_client_unlock_synced_data(vip->owning_client);
+
+    if (conn_manager != NULL) {
+        aws_http_connection_manager_release(conn_manager);
+        conn_manager = NULL;
+    }
+
+    if (finish_destroy) {
+        s_s3_client_vip_finish_destroy(vip);
+    }
+}
+
+static void s_s3_client_sub_vip_count_synced(struct aws_s3_client *client) {
+    AWS_PRECONDITION(client);
+    ASSERT_SYNCED_DATA_LOCK_HELD(client);
+    --client->synced_data.allocated_vip_count;
 }
 
 static void s_s3_client_vip_finish_destroy(void *user_data) {
     struct aws_s3_vip *vip = user_data;
     AWS_PRECONDITION(vip);
-
-    /* Release the VIP's reference to it's connection manager. */
-    aws_http_connection_manager_release(vip->http_connection_manager);
-    vip->http_connection_manager = NULL;
 
     /* Clean up the address string. */
     aws_string_destroy(vip->host_address);
@@ -646,26 +771,29 @@ static void s_s3_client_vip_finish_destroy(void *user_data) {
     struct aws_s3_client *client = vip->owning_client;
     aws_mem_release(client->allocator, vip);
 
-    s_s3_client_internal_release(client);
+    s_s3_client_check_for_shutdown(client, s_s3_client_sub_vip_count_synced);
 }
 
 /* Allocate a new VIP Connection structure for a given VIP. */
-struct aws_s3_vip_connection *aws_s3_vip_connection_new(struct aws_s3_client *client, struct aws_s3_vip *vip) {
+struct aws_s3_vip_connection *aws_s3_vip_connection_new_synced(struct aws_s3_client *client, struct aws_s3_vip *vip) {
     AWS_PRECONDITION(client);
     AWS_PRECONDITION(vip);
+    ASSERT_SYNCED_DATA_LOCK_HELD(client);
 
     struct aws_s3_vip_connection *vip_connection =
         aws_mem_calloc(client->allocator, 1, sizeof(struct aws_s3_vip_connection));
 
     vip_connection->owning_vip = vip;
-    aws_ref_count_acquire(&vip->internal_ref_count);
-
-    aws_http_connection_manager_acquire(vip->http_connection_manager);
-
-    /* Acquire internal reference for our VIP Connection structure. */
-    s_s3_client_internal_acquire(client);
+    ++vip->synced_data.num_vip_connections;
 
     return vip_connection;
+}
+
+static void s_s3_client_vip_sub_num_vip_connections_synced(struct aws_s3_vip *vip) {
+    AWS_PRECONDITION(vip);
+    AWS_PRECONDITION(vip->owning_client);
+    ASSERT_SYNCED_DATA_LOCK_HELD(vip->owning_client);
+    --vip->synced_data.num_vip_connections;
 }
 
 /* Destroy a VIP Connection structure. */
@@ -684,16 +812,11 @@ void s_s3_vip_connection_destroy(struct aws_s3_client *client, struct aws_s3_vip
 
             vip_connection->http_connection = NULL;
         }
-        aws_http_connection_manager_release(owning_vip->http_connection_manager);
     }
-
-    aws_ref_count_release(&owning_vip->internal_ref_count);
-    owning_vip = NULL;
-    vip_connection->owning_vip = NULL;
 
     aws_mem_release(client->allocator, vip_connection);
 
-    s_s3_client_internal_release(client);
+    s_s3_client_vip_check_for_shutdown(owning_vip, s_s3_client_vip_sub_num_vip_connections_synced);
 }
 
 static struct aws_s3_vip *s_s3_find_vip(
@@ -777,12 +900,14 @@ struct aws_s3_meta_request *aws_s3_client_make_meta_request(
 
     s_s3_client_lock_synced_data(client);
 
+    bool error_occurred = false;
+
     /* TODO This is temporary until we add multiple bucket support. */
     if (client->synced_data.endpoint == NULL) {
         client->synced_data.endpoint =
             aws_string_new_from_array(client->allocator, host_header_value.ptr, host_header_value.len);
     }
-
+unlock:
     s_s3_client_unlock_synced_data(client);
 
     if (s_s3_client_start_resolving_addresses(client)) {
@@ -927,9 +1052,11 @@ static int s_s3_client_add_vips(struct aws_s3_client *client, const struct aws_a
         goto unlock;
     }
 
+    struct aws_byte_cursor server_name = aws_byte_cursor_from_string(client->synced_data.endpoint);
+
     for (size_t address_index = 0; address_index < aws_array_list_length(host_addresses); ++address_index) {
 
-        if (client->synced_data.vip_count >= client->ideal_vip_count) {
+        if (client->synced_data.active_vip_count >= client->ideal_vip_count) {
             break;
         }
 
@@ -950,7 +1077,7 @@ static int s_s3_client_add_vips(struct aws_s3_client *client, const struct aws_a
         }
 
         /* Allocate the new VIP. */
-        vip = s_s3_client_vip_new(client, &host_address_byte_cursor);
+        vip = s_s3_client_vip_new_synced(client, &host_address_byte_cursor, &server_name);
 
         if (vip == NULL) {
             result = AWS_OP_ERR;
@@ -958,18 +1085,17 @@ static int s_s3_client_add_vips(struct aws_s3_client *client, const struct aws_a
         }
 
         aws_linked_list_push_back(&client->synced_data.vips, &vip->node);
-        ++client->synced_data.vip_count;
 
         AWS_LOGF_INFO(
             AWS_LS_S3_CLIENT,
-            "id=%p Initiating creation of VIP with address '%s', total vip count %d",
+            "id=%p Initiating creation of VIP with address '%s', total active vip count %d",
             (void *)client,
             (const char *)host_address_byte_cursor.ptr,
-            client->synced_data.vip_count);
+            client->synced_data.active_vip_count);
 
         /* Setup all of our vip connections. */
         for (size_t conn_index = 0; conn_index < s_num_connections_per_vip; ++conn_index) {
-            struct aws_s3_vip_connection *vip_connection = aws_s3_vip_connection_new(client, vip);
+            struct aws_s3_vip_connection *vip_connection = aws_s3_vip_connection_new_synced(client, vip);
 
             aws_linked_list_push_back(&client->synced_data.pending_vip_connection_updates, &vip_connection->node);
         }
@@ -1024,8 +1150,6 @@ static void s_s3_client_schedule_process_work_task_synced(struct aws_s3_client *
         return;
     }
 
-    s_s3_client_internal_acquire(client);
-
     aws_task_init(
         &client->synced_data.process_work_task, s_s3_client_process_work_task, client, "s3_client_process_work_task");
 
@@ -1067,6 +1191,12 @@ static void s_s3_client_remove_meta_request_threaded(
     aws_s3_meta_request_release(meta_request);
 }
 
+static void s_s3_client_reset_work_task_in_progress_synced(struct aws_s3_client *client) {
+    AWS_PRECONDITION(client);
+    ASSERT_SYNCED_DATA_LOCK_HELD(client);
+    client->synced_data.process_work_task_in_progress = false;
+}
+
 /* Task function for trying to find a request that can be processed. */
 static void s_s3_client_process_work_task(struct aws_task *task, void *arg, enum aws_task_status task_status) {
     AWS_PRECONDITION(task);
@@ -1094,6 +1224,7 @@ static void s_s3_client_process_work_task(struct aws_task *task, void *arg, enum
 
     /* Once we exit this mutex, someone can reschedule this task. */
     client->synced_data.process_work_task_scheduled = false;
+    client->synced_data.process_work_task_in_progress = true;
 
     aws_linked_list_swap_contents(&meta_request_work_list, &client->synced_data.pending_meta_request_work);
     aws_linked_list_swap_contents(&vip_connections_updates, &client->synced_data.pending_vip_connection_updates);
@@ -1229,7 +1360,7 @@ static void s_s3_client_process_work_task(struct aws_task *task, void *arg, enum
         }
     }
 
-    s_s3_client_internal_release(client);
+    s_s3_client_check_for_shutdown(client, s_s3_client_reset_work_task_in_progress_synced);
 }
 
 /* Handles getting an HTTP connection for the caller, given the vip_connection reference. */
@@ -1347,9 +1478,6 @@ static void s_s3_client_on_acquire_http_connection(
 
     aws_s3_meta_request_make_request(meta_request, client, vip_connection);
 
-    /* Get rid of our internal reference that we acquired for the lifetime of this async operation. */
-    s_s3_client_internal_release(client);
-
     return;
 
 error_clean_up:
@@ -1366,9 +1494,6 @@ error_clean_up:
     aws_linked_list_push_back(&client->synced_data.pending_vip_connection_updates, &vip_connection->node);
     s_s3_client_schedule_process_work_task_synced(client);
     s_s3_client_unlock_synced_data(client);
-
-    /* Get rid of our internal reference that we acquired for the lifetime of this async operation. */
-    s_s3_client_internal_release(client);
 }
 
 /* Called by aws_s3_meta_request when it has finished using this VIP connection for a single request. */
@@ -1413,10 +1538,16 @@ void aws_s3_client_stream_response_body(
     AWS_PRECONDITION(client);
     AWS_PRECONDITION(requests);
 
-    struct s3_streaming_body_payload *payload =
-        aws_mem_calloc(client->sba_allocator, 1, sizeof(struct s3_streaming_body_payload));
+    AWS_LOGF_DEBUG(
+        AWS_LS_S3_CLIENT,
+        "id=%p Scheduling body streaming task for meta request %p.",
+        (void *)client,
+        (void *)meta_request);
 
-    s_s3_client_internal_acquire(client);
+    struct s3_streaming_body_payload *payload =
+        aws_mem_calloc(client->allocator, 1, sizeof(struct s3_streaming_body_payload));
+
+    aws_s3_client_acquire(client);
     payload->client = client;
 
     aws_linked_list_init(&payload->requests);
@@ -1456,8 +1587,8 @@ static void s_s3_client_body_streaming_task(struct aws_task *task, void *arg, en
         aws_s3_request_release(request);
     }
 
-    aws_mem_release(client->sba_allocator, payload);
-    s_s3_client_internal_release(client);
+    aws_mem_release(client->allocator, payload);
+    aws_s3_client_release(client);
 }
 
 static void s_s3_client_on_host_resolver_address_resolved(
@@ -1511,10 +1642,20 @@ static void s_s3_client_host_listener_resolved_address_callback(
     s_s3_client_add_vips(client, host_addresses);
 }
 
+static void s_s3_client_set_host_listener_shutdown_synced(struct aws_s3_client *client) {
+    AWS_PRECONDITION(client);
+    ASSERT_SYNCED_DATA_LOCK_HELD(client);
+
+    AWS_LOGF_DEBUG(AWS_LS_S3_CLIENT, "id=%p: Host listener finished shutdown.", (void *)client);
+
+    client->synced_data.host_listener_allocated = false;
+}
+
 static void s_s3_client_host_listener_shutdown_callback(void *user_data) {
     AWS_PRECONDITION(user_data);
     struct aws_s3_client *client = user_data;
-    s_s3_client_internal_release(client);
+
+    s_s3_client_check_for_shutdown(client, s_s3_client_set_host_listener_shutdown_synced);
 }
 
 static int s_s3_client_start_resolving_addresses(struct aws_s3_client *client) {
@@ -1553,10 +1694,10 @@ static int s_s3_client_start_resolving_addresses(struct aws_s3_client *client) {
         goto unlock;
     }
 
-    /* Acquire internal ref for host listener so that we don't clean up until the listener shutdown callback is
-     * called.*/
-    s_s3_client_internal_acquire(client);
+    AWS_ASSERT(client->synced_data.active);
+
     client->synced_data.host_listener = host_listener;
+    client->synced_data.host_listener_allocated = true;
 
 unlock:
     s_s3_client_unlock_synced_data(client);
@@ -1574,9 +1715,6 @@ unlock:
     host_resolver_config.impl = aws_default_dns_resolve;
     host_resolver_config.max_ttl = s_default_dns_host_address_ttl_seconds;
     host_resolver_config.impl_data = client;
-
-    /* Acquire internal ref for resolve host callback so that we don't clean up until that callback is called. */
-    s_s3_client_internal_acquire(client);
 
     if (aws_host_resolver_resolve_host(
             host_resolver,

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -685,7 +685,7 @@ static void s_s3_vip_check_for_shutdown(struct aws_s3_vip *vip, s3_client_vip_up
         goto unlock;
     }
 
-    /* If the connection manager is active, then we can try initating a clean up of it now. */
+    /* If the connection manager is active, then we can try initiating a clean up of it now. */
     if (vip->synced_data.http_connection_manager_active) {
 
         /* If the connection manager is not NULL, take the pointer from the synced data so that it we can clean it up

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -1560,7 +1560,7 @@ void aws_s3_client_stream_response_body(
         (void *)meta_request);
 
     struct s3_streaming_body_payload *payload =
-        aws_mem_calloc(client->allocator, 1, sizeof(struct s3_streaming_body_payload));
+        aws_mem_calloc(client->sba_allocator, 1, sizeof(struct s3_streaming_body_payload));
 
     aws_s3_client_acquire(client);
     payload->client = client;
@@ -1602,7 +1602,7 @@ static void s_s3_client_body_streaming_task(struct aws_task *task, void *arg, en
         aws_s3_request_release(request);
     }
 
-    aws_mem_release(client->allocator, payload);
+    aws_mem_release(client->sba_allocator, payload);
     aws_s3_client_release(client);
 }
 
@@ -1639,8 +1639,6 @@ static void s_s3_client_on_host_resolver_address_resolved(
         AWS_ASSERT(host_addresses);
         s_s3_client_add_vips(client, host_addresses);
     }
-
-    s_s3_client_internal_release(client);
 }
 
 static void s_s3_client_host_listener_resolved_address_callback(

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -76,32 +76,13 @@ static void s_s3_client_finish_destroy(void *user_data);
 
 static void s_s3_client_body_streaming_elg_shutdown(void *user_data);
 
-/* Initializes/cleans-up a vip structure. */
-static struct aws_s3_vip *s_s3_client_vip_new_synced(
-    struct aws_s3_client *client,
-    const struct aws_byte_cursor *host_address,
-    const struct aws_byte_cursor *server_name);
+static void s_s3_vip_finish_destroy(void *user_data);
 
-static void s_s3_client_vip_destroy(struct aws_s3_vip *vip);
+static void s_s3_vip_http_connection_manager_shutdown_callback(void *user_data);
 
 typedef void(s3_client_vip_update_synced_data_state_fn)(struct aws_s3_vip *vip);
 
-static void s_s3_client_vip_http_connection_manager_shutdown_callback(void *user_data);
-
-/* Used to atomically update vip state during clean-up and check for finishing shutdown. */
-static void s_s3_client_vip_check_for_shutdown(
-    struct aws_s3_vip *vip,
-    s3_client_vip_update_synced_data_state_fn *update_fn);
-
-static void s_s3_client_vip_finish_destroy(void *user_data);
-
-/* Allocates/Destroy a VIP Connection structure. */
-struct aws_s3_vip_connection *aws_s3_vip_connection_new_synced(struct aws_s3_client *client, struct aws_s3_vip *vip);
-void s_s3_vip_connection_destroy(struct aws_s3_client *client, struct aws_s3_vip_connection *vip_connection);
-
-static struct aws_s3_vip *s_s3_find_vip(
-    const struct aws_linked_list *vip_list,
-    const struct aws_byte_cursor *host_address);
+static void s_s3_vip_check_for_shutdown(struct aws_s3_vip *vip, s3_client_vip_update_synced_data_state_fn *update_fn);
 
 static struct aws_s3_meta_request *s_s3_client_meta_request_factory_default(
     struct aws_s3_client *client,
@@ -114,25 +95,9 @@ static void s_s3_client_schedule_meta_request_work(
     struct aws_s3_meta_request *meta_request,
     enum aws_s3_meta_request_work_op op);
 
-/* Default push-meta-request function to be used in the client vtable. */
-static void s_s3_client_push_meta_request_default(
-    struct aws_s3_client *client,
-    struct aws_s3_meta_request *meta_request);
-
-/* Default remove-meta-request function to be used in the client vtable. */
-static void s_s3_client_remove_meta_request_default(
-    struct aws_s3_client *client,
-    struct aws_s3_meta_request *meta_request);
-
-/* Default remove-meta-request function to be used in the client vtable. */
-static void s_s3_client_get_http_connection(struct aws_s3_client *client, struct aws_s3_vip_connection *vip_connection);
-
 /* Handles getting an HTTP connection for the caller, given the vip_connection reference.  (Calls the corresponding
  * virtual function to do so.) */
-static void s_s3_client_get_http_connection_default(
-    struct aws_s3_client *client,
-    struct aws_s3_vip_connection *vip_connection,
-    aws_http_connection_manager_on_connection_setup_fn *on_connection_acquired_callback);
+static void s_s3_client_get_http_connection(struct aws_s3_client *client, struct aws_s3_vip_connection *vip_connection);
 
 /* Callback which handles the HTTP connection retrived by get_http_connection. */
 static void s_s3_client_on_acquire_http_connection(
@@ -155,6 +120,22 @@ static void s_s3_client_lock_synced_data(struct aws_s3_client *client) {
 static void s_s3_client_unlock_synced_data(struct aws_s3_client *client) {
     aws_mutex_unlock(&client->synced_data.lock);
 }
+
+/* Default push-meta-request function to be used in the client vtable. */
+static void s_s3_client_push_meta_request_default(
+    struct aws_s3_client *client,
+    struct aws_s3_meta_request *meta_request);
+
+/* Default remove-meta-request function to be used in the client vtable. */
+static void s_s3_client_remove_meta_request_default(
+    struct aws_s3_client *client,
+    struct aws_s3_meta_request *meta_request);
+
+/* Default remove-meta-request function to be used in the client vtable. */
+static void s_s3_client_get_http_connection_default(
+    struct aws_s3_client *client,
+    struct aws_s3_vip_connection *vip_connection,
+    aws_http_connection_manager_on_connection_setup_fn *on_connection_acquired_callback);
 
 static struct aws_s3_client_vtable s_s3_client_default_vtable = {
     .meta_request_factory = s_s3_client_meta_request_factory_default,
@@ -341,31 +322,10 @@ void aws_s3_client_release(struct aws_s3_client *client) {
     aws_ref_count_release(&client->ref_count);
 }
 
-void aws_s3_client_push_meta_request(struct aws_s3_client *client, struct aws_s3_meta_request *meta_request) {
+static void s_s3_client_reset_active_synced(struct aws_s3_client *client) {
     AWS_PRECONDITION(client);
-    AWS_PRECONDITION(client->vtable);
-    AWS_PRECONDITION(client->vtable->push_meta_request);
-
-    client->vtable->push_meta_request(client, meta_request);
-}
-
-void aws_s3_client_remove_meta_request(struct aws_s3_client *client, struct aws_s3_meta_request *meta_request) {
-    AWS_PRECONDITION(client);
-    AWS_PRECONDITION(client->vtable);
-    AWS_PRECONDITION(client->vtable->remove_meta_request);
-
-    client->vtable->remove_meta_request(client, meta_request);
-}
-
-static void s_s3_client_get_http_connection(
-    struct aws_s3_client *client,
-    struct aws_s3_vip_connection *vip_connection) {
-
-    AWS_PRECONDITION(client);
-    AWS_PRECONDITION(client->vtable);
-    AWS_PRECONDITION(client->vtable->get_http_connection);
-
-    client->vtable->get_http_connection(client, vip_connection, s_s3_client_on_acquire_http_connection);
+    ASSERT_SYNCED_DATA_LOCK_HELD(client);
+    client->synced_data.active = false;
 }
 
 static void s_s3_client_start_destroy(void *user_data) {
@@ -378,9 +338,6 @@ static void s_s3_client_start_destroy(void *user_data) {
     struct aws_host_listener *host_listener = NULL;
 
     s_s3_client_lock_synced_data(client);
-
-    AWS_ASSERT(client->synced_data.active);
-    client->synced_data.active = false;
 
     /* Grab the host listener from the synced_data so that we can remove it outside of the lock. */
     host_listener = client->synced_data.host_listener;
@@ -397,18 +354,26 @@ static void s_s3_client_start_destroy(void *user_data) {
         host_listener = NULL;
     }
 
-    /* Iterate through the local list, removing each VIP. */
-    while (!aws_linked_list_empty(&local_vip_list)) {
-        struct aws_linked_list_node *vip_node = aws_linked_list_pop_back(&local_vip_list);
+    if (!aws_linked_list_empty(&local_vip_list)) {
+        /* Iterate through the local list, removing each VIP. */
+        while (!aws_linked_list_empty(&local_vip_list)) {
+            struct aws_linked_list_node *vip_node = aws_linked_list_pop_back(&local_vip_list);
 
-        struct aws_s3_vip *vip = AWS_CONTAINER_OF(vip_node, struct aws_s3_vip, node);
+            struct aws_s3_vip *vip = AWS_CONTAINER_OF(vip_node, struct aws_s3_vip, node);
 
-        s_s3_client_vip_destroy(vip);
-        vip = NULL;
+            aws_s3_vip_start_destroy(vip);
+            vip = NULL;
+        }
+
+        s_s3_client_lock_synced_data(client);
+        s_s3_client_schedule_process_work_task_synced(client);
+        s_s3_client_unlock_synced_data(client);
     }
 
     aws_event_loop_group_release(client->body_streaming_elg);
     client->body_streaming_elg = NULL;
+
+    s_s3_client_check_for_shutdown(client, s_s3_client_reset_active_synced);
 }
 
 static void s_s3_client_check_for_shutdown(
@@ -486,25 +451,6 @@ static void s_s3_client_finish_destroy(void *user_data) {
     }
 }
 
-static void s_s3_client_vip_set_conn_manager_shutdown(struct aws_s3_vip *vip) {
-    AWS_PRECONDITION(vip);
-    AWS_PRECONDITION(vip->owning_client);
-    ASSERT_SYNCED_DATA_LOCK_HELD(vip->owning_client);
-    vip->synced_data.http_connection_manager_active = false;
-}
-
-static void s_s3_client_vip_http_connection_manager_shutdown_callback(void *user_data) {
-    AWS_PRECONDITION(user_data);
-
-    struct aws_s3_vip *vip = user_data;
-    AWS_PRECONDITION(vip);
-
-    AWS_LOGF_DEBUG(
-        AWS_LS_S3_CLIENT, "id=%p VIP %p Connection manager shutdown", (void *)vip->owning_client, (void *)vip);
-
-    s_s3_client_vip_check_for_shutdown(vip, s_s3_client_vip_set_conn_manager_shutdown);
-}
-
 static void s_s3_client_set_body_streaming_elg_shutdown_synced(struct aws_s3_client *client) {
     AWS_PRECONDITION(client);
     ASSERT_SYNCED_DATA_LOCK_HELD(client);
@@ -572,18 +518,27 @@ clean_up:
 }
 
 /* Initialize a new VIP structure for the client to use, given an address. Assumes lock is held. */
-static struct aws_s3_vip *s_s3_client_vip_new_synced(
+struct aws_s3_vip *aws_s3_vip_new(
     struct aws_s3_client *client,
     const struct aws_byte_cursor *host_address,
-    const struct aws_byte_cursor *server_name) {
-    ASSERT_SYNCED_DATA_LOCK_HELD(client);
+    const struct aws_byte_cursor *server_name,
+    uint32_t num_vip_connections,
+    struct aws_linked_list *out_vip_connections_list,
+    aws_s3_vip_shutdown_callback_fn *shutdown_callback,
+    void *shutdown_user_data) {
     AWS_PRECONDITION(client);
+    AWS_PRECONDITION(host_address);
+    AWS_PRECONDITION(server_name);
+    AWS_PRECONDITION(out_vip_connections_list);
 
     struct aws_s3_vip *vip = aws_mem_calloc(client->allocator, 1, sizeof(struct aws_s3_vip));
     vip->owning_client = client;
 
     /* Copy over the host address. */
     vip->host_address = aws_string_new_from_array(client->allocator, host_address->ptr, host_address->len);
+
+    vip->shutdown_callback = shutdown_callback;
+    vip->shutdown_user_data = shutdown_user_data;
 
     /* Try to set up an HTTP connection manager. */
     struct aws_socket_options socket_options;
@@ -598,8 +553,8 @@ static struct aws_s3_vip *s_s3_client_vip_new_synced(
     manager_options.initial_window_size = SIZE_MAX;
     manager_options.socket_options = &socket_options;
     manager_options.host = aws_byte_cursor_from_string(vip->host_address);
-    manager_options.max_connections = s_num_connections_per_vip;
-    manager_options.shutdown_complete_callback = s_s3_client_vip_http_connection_manager_shutdown_callback;
+    manager_options.max_connections = num_vip_connections;
+    manager_options.shutdown_complete_callback = s_s3_vip_http_connection_manager_shutdown_callback;
     manager_options.shutdown_complete_user_data = vip;
 
     struct aws_uri proxy_uri;
@@ -671,46 +626,43 @@ static struct aws_s3_vip *s_s3_client_vip_new_synced(
 
     aws_atomic_init_int(&vip->active, 1);
 
-    ++client->synced_data.allocated_vip_count;
-    ++client->synced_data.active_vip_count;
+    for (uint32_t i = 0; i < num_vip_connections; ++i) {
+        struct aws_s3_vip_connection *vip_connection =
+            aws_mem_calloc(client->allocator, 1, sizeof(struct aws_s3_vip_connection));
+
+        vip_connection->owning_vip = vip;
+        ++vip->synced_data.num_vip_connections;
+        aws_linked_list_push_back(out_vip_connections_list, &vip_connection->node);
+    }
+
     return vip;
 
 error_clean_up:
 
     if (vip != NULL) {
-        s_s3_client_vip_destroy(vip);
+        aws_mem_release(client->allocator, vip);
         vip = NULL;
     }
 
     return NULL;
 }
 
-static void s_s3_client_vip_set_reset_active(struct aws_s3_vip* vip) {
+static void s_s3_vip_set_reset_active(struct aws_s3_vip *vip) {
     AWS_PRECONDITION(vip);
 
     aws_atomic_store_int(&vip->active, 0);
 }
 
 /* Releases the memory for a vip structure. */
-static void s_s3_client_vip_destroy(struct aws_s3_vip *vip) {
-    AWS_PRECONDITION(vip);
+void aws_s3_vip_start_destroy(struct aws_s3_vip *vip) {
+    if (vip == NULL) {
+        return;
+    }
 
-    aws_atomic_store_int(&vip->active, 0);
-
-    s_s3_client_vip_check_for_shutdown(vip, s_s3_client_vip_set_reset_active);
-
-    struct aws_s3_client *client = vip->owning_client;
-
-    s_s3_client_lock_synced_data(client);
-    /* This vip is no longer being used, so subtract from active count so that another one can take its place. */
-    --client->synced_data.active_vip_count;
-    s_s3_client_schedule_process_work_task_synced(client);
-    s_s3_client_unlock_synced_data(client);
+    s_s3_vip_check_for_shutdown(vip, s_s3_vip_set_reset_active);
 }
 
-static void s_s3_client_vip_check_for_shutdown(
-    struct aws_s3_vip *vip,
-    s3_client_vip_update_synced_data_state_fn *update_fn) {
+static void s_s3_vip_check_for_shutdown(struct aws_s3_vip *vip, s3_client_vip_update_synced_data_state_fn *update_fn) {
     AWS_PRECONDITION(vip);
     AWS_PRECONDITION(vip->owning_client);
 
@@ -758,17 +710,30 @@ unlock:
     }
 
     if (finish_destroy) {
-        s_s3_client_vip_finish_destroy(vip);
+        s_s3_vip_finish_destroy(vip);
     }
 }
 
-static void s_s3_client_sub_vip_count_synced(struct aws_s3_client *client) {
-    AWS_PRECONDITION(client);
-    ASSERT_SYNCED_DATA_LOCK_HELD(client);
-    --client->synced_data.allocated_vip_count;
+static void s_s3_vip_set_conn_manager_shutdown(struct aws_s3_vip *vip) {
+    AWS_PRECONDITION(vip);
+    AWS_PRECONDITION(vip->owning_client);
+    ASSERT_SYNCED_DATA_LOCK_HELD(vip->owning_client);
+    vip->synced_data.http_connection_manager_active = false;
 }
 
-static void s_s3_client_vip_finish_destroy(void *user_data) {
+static void s_s3_vip_http_connection_manager_shutdown_callback(void *user_data) {
+    AWS_PRECONDITION(user_data);
+
+    struct aws_s3_vip *vip = user_data;
+    AWS_PRECONDITION(vip);
+
+    AWS_LOGF_DEBUG(
+        AWS_LS_S3_CLIENT, "id=%p VIP %p Connection manager shutdown", (void *)vip->owning_client, (void *)vip);
+
+    s_s3_vip_check_for_shutdown(vip, s_s3_vip_set_conn_manager_shutdown);
+}
+
+static void s_s3_vip_finish_destroy(void *user_data) {
     struct aws_s3_vip *vip = user_data;
     AWS_PRECONDITION(vip);
 
@@ -776,28 +741,18 @@ static void s_s3_client_vip_finish_destroy(void *user_data) {
     aws_string_destroy(vip->host_address);
     vip->host_address = NULL;
 
+    void *shutdown_user_data = vip->shutdown_user_data;
+    aws_s3_vip_shutdown_callback_fn *shutdown_callback = vip->shutdown_callback;
+
     struct aws_s3_client *client = vip->owning_client;
     aws_mem_release(client->allocator, vip);
 
-    s_s3_client_check_for_shutdown(client, s_s3_client_sub_vip_count_synced);
+    if (shutdown_callback != NULL) {
+        shutdown_callback(shutdown_user_data);
+    }
 }
 
-/* Allocate a new VIP Connection structure for a given VIP. */
-struct aws_s3_vip_connection *aws_s3_vip_connection_new_synced(struct aws_s3_client *client, struct aws_s3_vip *vip) {
-    AWS_PRECONDITION(client);
-    AWS_PRECONDITION(vip);
-    ASSERT_SYNCED_DATA_LOCK_HELD(client);
-
-    struct aws_s3_vip_connection *vip_connection =
-        aws_mem_calloc(client->allocator, 1, sizeof(struct aws_s3_vip_connection));
-
-    vip_connection->owning_vip = vip;
-    ++vip->synced_data.num_vip_connections;
-
-    return vip_connection;
-}
-
-static void s_s3_client_vip_sub_num_vip_connections_synced(struct aws_s3_vip *vip) {
+static void s_s3_vip_sub_num_vip_connections_synced(struct aws_s3_vip *vip) {
     AWS_PRECONDITION(vip);
     AWS_PRECONDITION(vip->owning_client);
     ASSERT_SYNCED_DATA_LOCK_HELD(vip->owning_client);
@@ -805,7 +760,7 @@ static void s_s3_client_vip_sub_num_vip_connections_synced(struct aws_s3_vip *vi
 }
 
 /* Destroy a VIP Connection structure. */
-void s_s3_vip_connection_destroy(struct aws_s3_client *client, struct aws_s3_vip_connection *vip_connection) {
+void aws_s3_vip_connection_destroy(struct aws_s3_client *client, struct aws_s3_vip_connection *vip_connection) {
 
     if (client == NULL || vip_connection == NULL) {
         return;
@@ -824,12 +779,10 @@ void s_s3_vip_connection_destroy(struct aws_s3_client *client, struct aws_s3_vip
 
     aws_mem_release(client->allocator, vip_connection);
 
-    s_s3_client_vip_check_for_shutdown(owning_vip, s_s3_client_vip_sub_num_vip_connections_synced);
+    s_s3_vip_check_for_shutdown(owning_vip, s_s3_vip_sub_num_vip_connections_synced);
 }
 
-static struct aws_s3_vip *s_s3_find_vip(
-    const struct aws_linked_list *vip_list,
-    const struct aws_byte_cursor *host_address) {
+struct aws_s3_vip *aws_s3_find_vip(const struct aws_linked_list *vip_list, const struct aws_byte_cursor *host_address) {
     AWS_PRECONDITION(vip_list);
 
     if (aws_linked_list_empty(vip_list)) {
@@ -908,14 +861,12 @@ struct aws_s3_meta_request *aws_s3_client_make_meta_request(
 
     s_s3_client_lock_synced_data(client);
 
-    bool error_occurred = false;
-
     /* TODO This is temporary until we add multiple bucket support. */
     if (client->synced_data.endpoint == NULL) {
         client->synced_data.endpoint =
             aws_string_new_from_array(client->allocator, host_header_value.ptr, host_header_value.len);
     }
-unlock:
+
     s_s3_client_unlock_synced_data(client);
 
     if (s_s3_client_start_resolving_addresses(client)) {
@@ -1047,6 +998,19 @@ static struct aws_s3_meta_request *s_s3_client_meta_request_factory_default(
     return NULL;
 }
 
+static void s_s3_client_sub_vip_count_synced(struct aws_s3_client *client) {
+    AWS_PRECONDITION(client);
+    ASSERT_SYNCED_DATA_LOCK_HELD(client);
+    --client->synced_data.allocated_vip_count;
+}
+
+static void s_s3_client_vip_shutdown_callback(void *user_data) {
+    AWS_PRECONDITION(user_data);
+    struct aws_s3_client *client = user_data;
+
+    s_s3_client_check_for_shutdown(client, s_s3_client_sub_vip_count_synced);
+}
+
 static int s_s3_client_add_vips(struct aws_s3_client *client, const struct aws_array_list *host_addresses) {
     AWS_PRECONDITION(client);
     AWS_PRECONDITION(host_addresses);
@@ -1080,17 +1044,32 @@ static int s_s3_client_add_vips(struct aws_s3_client *client, const struct aws_a
         struct aws_byte_cursor host_address_byte_cursor = aws_byte_cursor_from_string(host_address->address);
 
         /* If we didn't find a match in the table, we have a VIP to add! */
-        if (s_s3_find_vip(&client->synced_data.vips, &host_address_byte_cursor) != NULL) {
+        if (aws_s3_find_vip(&client->synced_data.vips, &host_address_byte_cursor) != NULL) {
             continue;
         }
 
+        struct aws_linked_list vip_connections;
+        aws_linked_list_init(&vip_connections);
+
         /* Allocate the new VIP. */
-        vip = s_s3_client_vip_new_synced(client, &host_address_byte_cursor, &server_name);
+        vip = aws_s3_vip_new(
+            client,
+            &host_address_byte_cursor,
+            &server_name,
+            s_num_connections_per_vip,
+            &vip_connections,
+            s_s3_client_vip_shutdown_callback,
+            client);
 
         if (vip == NULL) {
             result = AWS_OP_ERR;
             break;
         }
+
+        aws_linked_list_move_all_back(&client->synced_data.pending_vip_connection_updates, &vip_connections);
+
+        ++client->synced_data.allocated_vip_count;
+        ++client->synced_data.active_vip_count;
 
         aws_linked_list_push_back(&client->synced_data.vips, &vip->node);
 
@@ -1100,13 +1079,6 @@ static int s_s3_client_add_vips(struct aws_s3_client *client, const struct aws_a
             (void *)client,
             (const char *)host_address_byte_cursor.ptr,
             client->synced_data.active_vip_count);
-
-        /* Setup all of our vip connections. */
-        for (size_t conn_index = 0; conn_index < s_num_connections_per_vip; ++conn_index) {
-            struct aws_s3_vip_connection *vip_connection = aws_s3_vip_connection_new_synced(client, vip);
-
-            aws_linked_list_push_back(&client->synced_data.pending_vip_connection_updates, &vip_connection->node);
-        }
 
         s_s3_client_schedule_process_work_task_synced(client);
     }
@@ -1139,10 +1111,26 @@ static void s_s3_client_schedule_meta_request_work(
     s_s3_client_unlock_synced_data(client);
 }
 
+void aws_s3_client_push_meta_request(struct aws_s3_client *client, struct aws_s3_meta_request *meta_request) {
+    AWS_PRECONDITION(client);
+    AWS_PRECONDITION(client->vtable);
+    AWS_PRECONDITION(client->vtable->push_meta_request);
+
+    client->vtable->push_meta_request(client, meta_request);
+}
+
 static void s_s3_client_push_meta_request_default(
     struct aws_s3_client *client,
     struct aws_s3_meta_request *meta_request) {
     s_s3_client_schedule_meta_request_work(client, meta_request, AWS_S3_META_REQUEST_WORK_OP_PUSH);
+}
+
+void aws_s3_client_remove_meta_request(struct aws_s3_client *client, struct aws_s3_meta_request *meta_request) {
+    AWS_PRECONDITION(client);
+    AWS_PRECONDITION(client->vtable);
+    AWS_PRECONDITION(client->vtable->remove_meta_request);
+
+    client->vtable->remove_meta_request(client, meta_request);
 }
 
 static void s_s3_client_remove_meta_request_default(
@@ -1311,7 +1299,7 @@ static void s_s3_client_process_work_task(struct aws_task *task, void *arg, enum
 
         /* If this VIP connection is pending destruction, go ahead and clean it up now. */
         if (owning_vip_active == 0) {
-            s_s3_vip_connection_destroy(client, vip_connection);
+            aws_s3_vip_connection_destroy(client, vip_connection);
             continue;
         }
 
@@ -1369,6 +1357,17 @@ static void s_s3_client_process_work_task(struct aws_task *task, void *arg, enum
     }
 
     s_s3_client_check_for_shutdown(client, s_s3_client_reset_work_task_in_progress_synced);
+}
+
+static void s_s3_client_get_http_connection(
+    struct aws_s3_client *client,
+    struct aws_s3_vip_connection *vip_connection) {
+
+    AWS_PRECONDITION(client);
+    AWS_PRECONDITION(client->vtable);
+    AWS_PRECONDITION(client->vtable->get_http_connection);
+
+    client->vtable->get_http_connection(client, vip_connection, s_s3_client_on_acquire_http_connection);
 }
 
 /* Handles getting an HTTP connection for the caller, given the vip_connection reference. */

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -196,6 +196,7 @@ int aws_s3_meta_request_init_base(
         sizeof(struct aws_s3_request *),
         s_s3_request_priority_queue_pred);
 
+    /* Client is currently optional to allow spining up a meta_request without a client in a test. */
     if (client != NULL) {
         aws_s3_client_acquire(client);
         meta_request->synced_data.client = client;

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -377,8 +377,10 @@ static void s_s3_request_destroy(void *user_data) {
         return;
     }
 
-    if (request->meta_request != NULL) {
-        struct aws_s3_client *client = aws_s3_meta_request_acquire_client(request->meta_request);
+    struct aws_s3_meta_request *meta_request = request->meta_request;
+
+    if (meta_request != NULL) {
+        struct aws_s3_client *client = aws_s3_meta_request_acquire_client(meta_request);
 
         if (client != NULL) {
             aws_s3_client_notify_request_destroyed(client);
@@ -386,14 +388,14 @@ static void s_s3_request_destroy(void *user_data) {
             client = NULL;
         }
 
-        s_s3_meta_request_notify_request_destroyed(request->meta_request, request);
+        s_s3_meta_request_notify_request_destroyed(meta_request, request);
     }
 
     aws_s3_request_clean_up_send_data(request);
-    aws_s3_meta_request_release(request->meta_request);
     aws_byte_buf_clean_up(&request->request_body);
     aws_retry_token_release(request->retry_token);
     aws_mem_release(request->allocator, request);
+    aws_s3_meta_request_release(meta_request);
 }
 
 struct aws_s3_request *aws_s3_meta_request_next_request(struct aws_s3_meta_request *meta_request) {


### PR DESCRIPTION
*Description:*
* Taking out internal_acquire/release semantics because it was confusing and likely creating bugs.  (The original idea was, internal references do not prevent clean up from initiating, but would prevent clean-up from finishing until all internal references are released.)
* Moving around some functions in the client file/adding comments to better re-organize.
* Adjusting VIP logic to make it easier to unit test (and maybe move to a separate file in the future).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
