### PR TITLE
Parse XML response error

### DIFF
--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -142,7 +142,7 @@ struct aws_s3_meta_request_result {
     struct aws_http_headers *error_response_headers;
 
     /* Response body for the failed request that triggered finishing of the meta request.  NUll if no request failed.*/
-    struct aws_byte_buf *error_response_body;
+    struct aws_byte_cursor *error_response_body;
 
     /* Response status of the failed request or of the entire meta request. */
     int response_status;

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -142,7 +142,7 @@ struct aws_s3_meta_request_result {
     struct aws_http_headers *error_response_headers;
 
     /* Response body for the failed request that triggered finishing of the meta request.  NUll if no request failed.*/
-    struct aws_byte_cursor *error_response_body;
+    struct aws_byte_cursor error_response_body;
 
     /* Response status of the failed request or of the entire meta request. */
     int response_status;

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -142,7 +142,7 @@ struct aws_s3_meta_request_result {
     struct aws_http_headers *error_response_headers;
 
     /* Response body for the failed request that triggered finishing of the meta request.  NUll if no request failed.*/
-    struct aws_byte_cursor error_response_body;
+    struct aws_byte_cursor *error_response_body;
 
     /* Response status of the failed request or of the entire meta request. */
     int response_status;

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -1099,39 +1099,15 @@ unlock:
             .response_status = response_status,
         };
 
-        struct aws_string *error_message = NULL;
-        struct aws_byte_cursor error_body_cursor;
-        AWS_ZERO_STRUCT(error_body_cursor);
         if (error_code == AWS_ERROR_S3_INVALID_RESPONSE_STATUS && failed_request != NULL) {
             meta_request_result.error_response_headers = failed_request->send_data.response_headers;
-            if (failed_request->send_data.response_headers) {
-                struct aws_byte_cursor content_type;
-                AWS_ZERO_STRUCT(content_type);
 
-                if (!aws_http_headers_get(
-                        failed_request->send_data.response_headers,
-                        aws_byte_cursor_from_c_str("content-type"),
-                        &content_type)) {
-                    /* Content type found */
-                    if (aws_byte_cursor_eq_c_str_ignore_case(&content_type, "application/xml")) {
-                        /* XML response */
-                        struct aws_byte_cursor body_cursor =
-                            aws_byte_cursor_from_buf(&failed_request->send_data.response_body);
-                        struct aws_byte_cursor tag = aws_byte_cursor_from_c_str("Message");
-                        error_message = get_top_level_xml_tag_value(meta_request->allocator, &tag, &body_cursor);
-                    }
-                }
-            }
-            if (error_message) {
-                error_body_cursor = aws_byte_cursor_from_string(error_message);
-            } else {
-                error_body_cursor = aws_byte_cursor_from_buf(&failed_request->send_data.response_body);
-            }
+            struct aws_byte_cursor error_body_cursor =
+                aws_byte_cursor_from_buf(&failed_request->send_data.response_body);
             meta_request_result.error_response_body = &error_body_cursor;
         }
 
         meta_request->finish_callback(meta_request, &meta_request_result, meta_request->user_data);
-        aws_string_destroy(error_message);
     }
 }
 

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -1099,12 +1099,38 @@ unlock:
             .response_status = response_status,
         };
 
+        struct aws_string *error_message = NULL;
         if (error_code == AWS_ERROR_S3_INVALID_RESPONSE_STATUS && failed_request != NULL) {
             meta_request_result.error_response_headers = failed_request->send_data.response_headers;
-            meta_request_result.error_response_body = &failed_request->send_data.response_body;
+            if (failed_request->send_data.response_headers) {
+                struct aws_byte_cursor content_type;
+                AWS_ZERO_STRUCT(content_type);
+
+                if (!aws_http_headers_get(
+                        failed_request->send_data.response_headers,
+                        aws_byte_cursor_from_c_str("content-type"),
+                        &content_type)) {
+                    /* Content type found */
+                    if (aws_byte_cursor_eq_c_str_ignore_case(&content_type, "application/xml")) {
+                        /* XML response */
+                        struct aws_byte_cursor body_cursor =
+                            aws_byte_cursor_from_buf(&failed_request->send_data.response_body);
+                        struct aws_byte_cursor tag = aws_byte_cursor_from_c_str("Message");
+                        error_message = get_top_level_xml_tag_value(meta_request->allocator, &tag, &body_cursor);
+                    }
+                }
+            }
+            struct aws_byte_cursor error_body_cursor;
+            if (error_message) {
+                error_body_cursor = aws_byte_cursor_from_string(error_message);
+            } else {
+                error_body_cursor = aws_byte_cursor_from_buf(&failed_request->send_data.response_body);
+            }
+            meta_request_result.error_response_body = &error_body_cursor;
         }
 
         meta_request->finish_callback(meta_request, &meta_request_result, meta_request->user_data);
+        aws_string_destroy(error_message);
     }
 }
 

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -1091,12 +1091,10 @@ unlock:
         aws_error_str(error_code));
 
     if (meta_request->finish_callback != NULL) {
-        struct aws_byte_cursor error_body_cursor;
-        AWS_ZERO_STRUCT(error_body_cursor);
 
         struct aws_s3_meta_request_result meta_request_result = {
             .error_response_headers = NULL,
-            .error_response_body = error_body_cursor,
+            .error_response_body = NULL,
             .error_code = error_code,
             .response_status = response_status,
         };
@@ -1104,7 +1102,6 @@ unlock:
         struct aws_string *error_message = NULL;
         if (error_code == AWS_ERROR_S3_INVALID_RESPONSE_STATUS && failed_request != NULL) {
             meta_request_result.error_response_headers = failed_request->send_data.response_headers;
-            error_body_cursor = aws_byte_cursor_from_buf(&failed_request->send_data.response_body);
             if (failed_request->send_data.response_headers) {
                 struct aws_byte_cursor content_type;
                 AWS_ZERO_STRUCT(content_type);
@@ -1113,18 +1110,23 @@ unlock:
                         failed_request->send_data.response_headers,
                         aws_byte_cursor_from_c_str("content-type"),
                         &content_type)) {
+                    /* Content type found */
                     if (aws_byte_cursor_eq_c_str_ignore_case(&content_type, "application/xml")) {
                         /* XML response */
+                        struct aws_byte_cursor body_cursor =
+                            aws_byte_cursor_from_buf(&failed_request->send_data.response_body);
                         struct aws_byte_cursor tag = aws_byte_cursor_from_c_str("Message");
-                        error_message = get_top_level_xml_tag_value(meta_request->allocator, &tag, &error_body_cursor);
+                        error_message = get_top_level_xml_tag_value(meta_request->allocator, &tag, &body_cursor);
                     }
                 }
             }
+            struct aws_byte_cursor error_body_cursor;
             if (error_message) {
-                /* overwrite the previous cursor with the decode message */
                 error_body_cursor = aws_byte_cursor_from_string(error_message);
+            } else {
+                error_body_cursor = aws_byte_cursor_from_buf(&failed_request->send_data.response_body);
             }
-            meta_request_result.error_response_body = error_body_cursor;
+            meta_request_result.error_response_body = &error_body_cursor;
         }
 
         meta_request->finish_callback(meta_request, &meta_request_result, meta_request->user_data);

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -1100,6 +1100,8 @@ unlock:
         };
 
         struct aws_string *error_message = NULL;
+        struct aws_byte_cursor error_body_cursor;
+        AWS_ZERO_STRUCT(error_body_cursor);
         if (error_code == AWS_ERROR_S3_INVALID_RESPONSE_STATUS && failed_request != NULL) {
             meta_request_result.error_response_headers = failed_request->send_data.response_headers;
             if (failed_request->send_data.response_headers) {
@@ -1120,7 +1122,6 @@ unlock:
                     }
                 }
             }
-            struct aws_byte_cursor error_body_cursor;
             if (error_message) {
                 error_body_cursor = aws_byte_cursor_from_string(error_message);
             } else {

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -82,10 +82,8 @@ static void s_s3_test_meta_request_finish(
         aws_http_headers_acquire(result->error_response_headers);
     }
 
-    if (result->error_response_body != NULL) {
-        aws_byte_buf_init_copy_from_cursor(
-            &meta_request_test_results->error_response_body, tester->allocator, *result->error_response_body);
-    }
+    aws_byte_buf_init_copy_from_cursor(
+        &meta_request_test_results->error_response_body, tester->allocator, result->error_response_body);
 
     meta_request_test_results->finished_response_status = result->response_status;
     meta_request_test_results->finished_error_code = result->error_code;

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -83,7 +83,8 @@ static void s_s3_test_meta_request_finish(
     }
 
     if (result->error_response_body != NULL) {
-        meta_request_test_results->error_response_body = *result->error_response_body;
+        aws_byte_buf_init_copy_from_cursor(
+            &meta_request_test_results->error_response_body, tester->allocator, *result->error_response_body);
     }
 
     meta_request_test_results->finished_response_status = result->response_status;
@@ -268,6 +269,7 @@ void aws_s3_meta_request_test_results_clean_up(struct aws_s3_meta_request_test_r
     }
 
     aws_http_headers_release(test_meta_request->error_response_headers);
+    aws_byte_buf_clean_up(&test_meta_request->error_response_body);
     aws_http_headers_release(test_meta_request->response_headers);
 
     AWS_ZERO_STRUCT(*test_meta_request);

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -83,8 +83,7 @@ static void s_s3_test_meta_request_finish(
     }
 
     if (result->error_response_body != NULL) {
-        aws_byte_buf_init_copy(
-            &meta_request_test_results->error_response_body, tester->allocator, result->error_response_body);
+        meta_request_test_results->error_response_body = *result->error_response_body;
     }
 
     meta_request_test_results->finished_response_status = result->response_status;
@@ -269,7 +268,6 @@ void aws_s3_meta_request_test_results_clean_up(struct aws_s3_meta_request_test_r
     }
 
     aws_http_headers_release(test_meta_request->error_response_headers);
-    aws_byte_buf_clean_up(&test_meta_request->error_response_body);
     aws_http_headers_release(test_meta_request->response_headers);
 
     AWS_ZERO_STRUCT(*test_meta_request);

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -82,8 +82,10 @@ static void s_s3_test_meta_request_finish(
         aws_http_headers_acquire(result->error_response_headers);
     }
 
-    aws_byte_buf_init_copy_from_cursor(
-        &meta_request_test_results->error_response_body, tester->allocator, result->error_response_body);
+    if (result->error_response_body != NULL) {
+        aws_byte_buf_init_copy_from_cursor(
+            &meta_request_test_results->error_response_body, tester->allocator, *result->error_response_body);
+    }
 
     meta_request_test_results->finished_response_status = result->response_status;
     meta_request_test_results->finished_error_code = result->error_code;

--- a/tests/s3_tester.h
+++ b/tests/s3_tester.h
@@ -76,7 +76,7 @@ struct aws_s3_meta_request_test_results {
     struct aws_s3_tester *tester;
 
     struct aws_http_headers *error_response_headers;
-    struct aws_byte_cursor error_response_body;
+    struct aws_byte_buf error_response_body;
     size_t part_size;
 
     int headers_response_status;

--- a/tests/s3_tester.h
+++ b/tests/s3_tester.h
@@ -76,7 +76,7 @@ struct aws_s3_meta_request_test_results {
     struct aws_s3_tester *tester;
 
     struct aws_http_headers *error_response_headers;
-    struct aws_byte_buf error_response_body;
+    struct aws_byte_cursor error_response_body;
     size_t part_size;
 
     int headers_response_status;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- byte_buf to byte_cursor for the body of error
- If we have a XML type of error response, parse the message to have better error report

Debatable:
Parsing XML response should be here at native client? Or should it be some user level code?
Since I don't think any user level code will need the whole body, so put it here. But, maybe I am wrong.

TODO:
- Special error handling for getting an empty file?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
