### PR TITLE
Fixing Meta Request Ref Count Bug

### DIFF
--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -102,8 +102,6 @@ struct aws_s3_client_vtable {
 
     void (*push_meta_request)(struct aws_s3_client *client, struct aws_s3_meta_request *meta_request);
 
-    void (*remove_meta_request)(struct aws_s3_client *client, struct aws_s3_meta_request *meta_request);
-
     void (*acquire_http_connection)(
         struct aws_s3_client *client,
         struct aws_s3_vip_connection *vip_connection,
@@ -240,8 +238,6 @@ struct aws_s3_client {
 };
 
 void aws_s3_client_push_meta_request(struct aws_s3_client *client, struct aws_s3_meta_request *meta_request);
-
-void aws_s3_client_remove_meta_request(struct aws_s3_client *client, struct aws_s3_meta_request *meta_request);
 
 int aws_s3_client_make_request(struct aws_s3_client *client, struct aws_s3_vip_connection *vip_connection);
 

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -119,23 +119,6 @@ void aws_s3_meta_request_push_to_client(struct aws_s3_meta_request *meta_request
     aws_s3_client_release(client);
 }
 
-void aws_s3_meta_request_remove_from_client(struct aws_s3_meta_request *meta_request) {
-    AWS_PRECONDITION(meta_request);
-
-    struct aws_s3_client *client = aws_s3_meta_request_acquire_client(meta_request);
-
-    if (client != NULL) {
-        aws_s3_client_remove_meta_request(client, meta_request);
-    } else {
-        AWS_LOGF_DEBUG(
-            AWS_LS_S3_META_REQUEST,
-            "id=%p Meta request trying to schedule work but client is null.",
-            (void *)meta_request);
-    }
-
-    aws_s3_client_release(client);
-}
-
 int aws_s3_meta_request_init_base(
     struct aws_allocator *allocator,
     struct aws_s3_client *client,

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -488,7 +488,6 @@ void aws_s3_tester_unlock_synced_data(struct aws_s3_tester *tester) {
 
 struct aws_s3_client_vtable g_aws_s3_client_mock_vtable = {
     .push_meta_request = aws_s3_client_push_meta_request_empty,
-    .remove_meta_request = aws_s3_client_remove_meta_request_empty,
     .acquire_http_connection = aws_s3_client_acquire_http_connection_empty,
 };
 
@@ -1320,11 +1319,6 @@ int aws_s3_tester_validate_put_object_results(
 }
 
 void aws_s3_client_push_meta_request_empty(struct aws_s3_client *client, struct aws_s3_meta_request *meta_request) {
-    (void)client;
-    (void)meta_request;
-}
-
-void aws_s3_client_remove_meta_request_empty(struct aws_s3_client *client, struct aws_s3_meta_request *meta_request) {
     (void)client;
     (void)meta_request;
 }

--- a/tests/s3_tester.h
+++ b/tests/s3_tester.h
@@ -317,8 +317,6 @@ int aws_s3_tester_validate_put_object_results(
 /* Used for mocking functions in vtables */
 void aws_s3_client_push_meta_request_empty(struct aws_s3_client *client, struct aws_s3_meta_request *meta_request);
 
-void aws_s3_client_remove_meta_request_empty(struct aws_s3_client *client, struct aws_s3_meta_request *meta_request);
-
 void aws_s3_client_acquire_http_connection_empty(
     struct aws_s3_client *client,
     struct aws_s3_vip_connection *vip_connection,


### PR DESCRIPTION
* Fixing Meta Request ref count bug where a double schedule wouldn't release the reference.
* Removing Meta-Request-Remove functionality since it's not used/unneeded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
