### PR TITLE
Moving library clean up call

### DIFF
--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -472,9 +472,9 @@ void aws_s3_tester_clean_up(struct aws_s3_tester *tester) {
     aws_condition_variable_clean_up(&tester->signal);
     aws_mutex_clean_up(&tester->synced_data.lock);
 
-    aws_s3_library_clean_up();
-
     aws_global_thread_creator_shutdown_wait_for(10);
+
+    aws_s3_library_clean_up();
 }
 
 void aws_s3_tester_lock_synced_data(struct aws_s3_tester *tester) {


### PR DESCRIPTION
*Description of changes:*
Not sure why this isn't a more consistent issue for other platforms, but appears to fairly consistently cause tests to fail on Ubuntu.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
