### PR TITLE
Net tests and new crash

### DIFF
--- a/include/aws/s3/private/s3_util.h
+++ b/include/aws/s3/private/s3_util.h
@@ -44,7 +44,10 @@ extern const struct aws_byte_cursor g_s3_service_name;
 extern const struct aws_byte_cursor g_range_header_name;
 extern const struct aws_byte_cursor g_content_range_header_name;
 extern const struct aws_byte_cursor g_accept_ranges_header_name;
+
+AWS_S3_API
 extern const struct aws_byte_cursor g_acl_header_name;
+
 extern const struct aws_byte_cursor g_post_method;
 extern const struct aws_byte_cursor g_delete_method;
 extern const uint32_t g_s3_max_num_upload_parts;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ file(GLOB TEST_SRC "*.c")
 file(GLOB TEST_HDRS "*.h")
 file(GLOB TESTS ${TEST_HDRS} ${TEST_SRC})
 
-add_test_case(test_s3_client_create_destroy)
+add_net_test_case(test_s3_client_create_destroy)
 add_test_case(test_s3_request_create_destroy)
 
 add_net_test_case(test_s3_client_exceed_retries)
@@ -16,8 +16,8 @@ add_net_test_case(test_s3_meta_request_sign_request_fail)
 add_net_test_case(test_s3_meta_request_send_request_finish_fail)
 add_net_test_case(test_s3_auto_range_put_missing_upload_id)
 
-add_test_case(test_s3_vip_create_destroy)
-add_test_case(test_s3_client_add_remove_vips)
+add_net_test_case(test_s3_vip_create_destroy)
+add_net_test_case(test_s3_client_add_remove_vips)
 add_net_test_case(test_s3_client_resolve_vips)
 
 add_net_test_case(test_s3_get_object_tls_disabled)


### PR DESCRIPTION
* Marks a few more tests as net tests since they initialize a tls context which will fail in internal builds (no file sys/network)
* Fixes a crash in the cleanup of an s3 client if the tls initialization failed (linked list members not initialized early enough)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
