### PR TITLE
Removing aws_s3_meta_request_acquire_client

### DIFF
--- a/include/aws/s3/private/s3_meta_request_impl.h
+++ b/include/aws/s3/private/s3_meta_request_impl.h
@@ -104,6 +104,10 @@ struct aws_s3_meta_request {
 
     struct aws_cached_signing_config_aws *cached_signing_config;
 
+    /* Client that created this meta request which also processes this request.  After the meta request is finished,
+     * this reference is removed. */
+    struct aws_s3_client *client;
+
     /* User data to be passed to each customer specified callback.*/
     void *user_data;
 
@@ -115,10 +119,6 @@ struct aws_s3_meta_request {
 
     struct {
         struct aws_mutex lock;
-
-        /* Client that created this meta request which also processes this request.  After the meta request is finished,
-         * this reference is removed. */
-        struct aws_s3_client *client;
 
         /* Priority queue for pending streaming requests.  We use a priority queue to keep parts in order so that we
          * can stream them to the caller in order. */
@@ -202,11 +202,6 @@ void aws_s3_meta_request_lock_synced_data(struct aws_s3_meta_request *meta_reque
 
 AWS_S3_API
 void aws_s3_meta_request_unlock_synced_data(struct aws_s3_meta_request *meta_request);
-
-/* Gets the client reference in the meta request synced_data, acquiring a reference to it if it exists. After calling
- * this function, it is necessary to release that reference. */
-AWS_S3_API
-struct aws_s3_client *aws_s3_meta_request_acquire_client(struct aws_s3_meta_request *meta_request);
 
 /* Called by the client to retrieve the next request and update the meta request's internal state. out_request is
  * optional, and can be NULL if just desiring to update internal state. */

--- a/source/s3_request.c
+++ b/source/s3_request.c
@@ -39,7 +39,7 @@ void aws_s3_request_setup_send_data(struct aws_s3_request *request, struct aws_h
     aws_http_message_acquire(message);
 }
 
-void s_s3_request_clean_up_send_data_message(struct aws_s3_request *request) {
+static void s_s3_request_clean_up_send_data_message(struct aws_s3_request *request) {
     AWS_PRECONDITION(request);
 
     struct aws_http_message *message = request->send_data.message;
@@ -98,12 +98,10 @@ static void s_s3_request_destroy(void *user_data) {
     struct aws_s3_meta_request *meta_request = request->meta_request;
 
     if (meta_request != NULL) {
-        struct aws_s3_client *client = aws_s3_meta_request_acquire_client(meta_request);
+        struct aws_s3_client *client = meta_request->client;
 
         if (client != NULL) {
             aws_s3_client_notify_request_destroyed(client, request);
-            aws_s3_client_release(client);
-            client = NULL;
         }
     }
 

--- a/tests/s3_retry_tests.c
+++ b/tests/s3_retry_tests.c
@@ -297,14 +297,11 @@ static void s_s3_meta_request_send_request_finish_fail_first(
     struct aws_http_stream *stream,
     int error_code) {
 
-    struct aws_s3_client *client = aws_s3_meta_request_acquire_client(vip_connection->request->meta_request);
+    struct aws_s3_client *client = vip_connection->request->meta_request->client;
     AWS_ASSERT(client != NULL);
 
     struct aws_s3_tester *tester = client->shutdown_callback_user_data;
     AWS_ASSERT(tester != NULL);
-
-    aws_s3_client_release(client);
-    client = NULL;
 
     if (aws_s3_tester_inc_counter2(tester) == 1) {
         AWS_ASSERT(vip_connection->request->send_data.response_status == 404);
@@ -376,11 +373,8 @@ static void s_finished_request_remove_upload_id(
         aws_byte_buf_reset(&request->send_data.response_body, false);
     }
 
-    struct aws_s3_client *client = aws_s3_meta_request_acquire_client(meta_request);
+    struct aws_s3_client *client = meta_request->client;
     struct aws_s3_tester *tester = client->shutdown_callback_user_data;
-
-    aws_s3_client_release(client);
-    client = NULL;
 
     struct aws_s3_meta_request_vtable *original_meta_request_vtable =
         aws_s3_tester_get_meta_request_vtable_patch(tester, 0)->original_vtable;


### PR DESCRIPTION
*Description of changes:*
Removing aws_s3_meta_request_acquire_client from aws_s3_meta_request in favor of making it directly accessible.  

The justification for this is that the client variable is set on the meta request at creation and is only cleared when the meta request finishes.  When the meta request finishes, all parallel work is, by design, intended to have been completed. 
 Because of this, it's more cumbersome/error-prone to keep it inside of synced_data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
