### PR TITLE
Fixing bug with num_active_vip_connections counter

### DIFF
--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -1364,8 +1364,13 @@ static void s_s3_client_assign_requests_to_connections_threaded(
             (!client_active || (vip_connection->http_connection == NULL ||
                                 !aws_http_connection_is_open(vip_connection->http_connection) ||
                                 vip_connection->request_count >= s_s3_max_request_count_per_connection))) {
+
+            if (vip_connection->is_active) {
+                --client->threaded_data.num_active_vip_connections;
+                vip_connection->is_active = false;
+            }
+
             aws_s3_vip_connection_destroy(client, vip_connection);
-            --client->threaded_data.num_active_vip_connections;
             continue;
         }
 

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -1366,7 +1366,12 @@ static void s_s3_client_assign_requests_to_connections_threaded(
                                 vip_connection->request_count >= s_s3_max_request_count_per_connection))) {
 
             if (vip_connection->is_active) {
-                --client->threaded_data.num_active_vip_connections;
+                int sub_result = aws_sub_u32_checked(
+                    client->threaded_data.num_active_vip_connections,
+                    1,
+                    &client->threaded_data.num_active_vip_connections);
+                AWS_ASSERT(sub_result == AWS_OP_SUCCESS);
+
                 vip_connection->is_active = false;
             }
 

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -1371,6 +1371,7 @@ static void s_s3_client_assign_requests_to_connections_threaded(
                     1,
                     &client->threaded_data.num_active_vip_connections);
                 AWS_ASSERT(sub_result == AWS_OP_SUCCESS);
+                (void)sub_result;
 
                 vip_connection->is_active = false;
             }


### PR DESCRIPTION
*Description of changes:*
Fixing bug with num_active_vip_connections counter.

There is a change in an upcoming PR that better couples the boolean with the counter (https://github.com/awslabs/aws-c-s3/blob/improving_request_prep/source/s3_client.c#L809).  We could pull that into this PR, but it's a less isolated change that'll pull in other changes as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
