### PR TITLE
Changing Compute MD5 default

### DIFF
--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -178,7 +178,8 @@ struct aws_s3_client {
     /**
      * For multi-part upload, content-md5 will be calculated if the AWS_MR_CONTENT_MD5_ENABLED is specified
      *     or initial request has content-md5 header.
-     * For single-part upload, keep the content-md5 in the initial request unchanged. */
+     * For single-part upload, if the content-md5 header is specified, it will remain unchanged. If the header is not
+     *     specified, and this is set to AWS_MR_CONTENT_MD5_ENABLED, it will be calculated. */
     const enum aws_s3_meta_request_compute_content_md5 compute_content_md5;
 
     /* Hard limit on max connections set through the client config. */

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -67,8 +67,8 @@ enum aws_s3_meta_request_tls_mode {
 };
 
 enum aws_s3_meta_request_compute_content_md5 {
-    AWS_MR_CONTENT_MD5_ENABLED,
     AWS_MR_CONTENT_MD5_DISABLED,
+    AWS_MR_CONTENT_MD5_ENABLED,
 };
 
 /* Options for a new client. */


### PR DESCRIPTION
*Description of changes:*
* Changing compute-MD5 default of CRT Client to disabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
