### PR TITLE
Small bug fixes

### DIFF
--- a/include/aws/s3/private/s3_meta_request_impl.h
+++ b/include/aws/s3/private/s3_meta_request_impl.h
@@ -52,9 +52,8 @@ struct aws_s3_prepare_request_payload {
 };
 
 struct aws_s3_meta_request_vtable {
-    /* Update the meta request.  out_request is optional and can be NULL. If not null, and a request can be returned, it
-     * will be passed back into this variable. Returns true if there is there is any work in progress, false if there is
-     * not. */
+    /* Update the meta request.  out_request is required to be non-null. Returns true if there is there is any work in
+     * progress, false if there is not. */
     bool (*update)(struct aws_s3_meta_request *meta_request, uint32_t flags, struct aws_s3_request **out_request);
 
     void (*schedule_prepare_request)(

--- a/include/aws/s3/private/s3_util.h
+++ b/include/aws/s3/private/s3_util.h
@@ -12,7 +12,16 @@
 #include <aws/common/byte_buf.h>
 #include <aws/s3/s3.h>
 
-#define ASSERT_SYNCED_DATA_LOCK_HELD(object) AWS_ASSERT(aws_mutex_try_lock(&(object)->synced_data.lock) == AWS_OP_ERR)
+#if DEBUG_BUILD
+#    define ASSERT_SYNCED_DATA_LOCK_HELD(object)                                                                       \
+        {                                                                                                              \
+            int cached_error = aws_last_error();                                                                       \
+            AWS_ASSERT(aws_mutex_try_lock(&(object)->synced_data.lock) == AWS_OP_ERR);                                 \
+            aws_raise_error(cached_error);                                                                             \
+        }
+#else
+#    define ASSERT_SYNCED_DATA_LOCK_HELD(object)
+#endif
 #define KB_TO_BYTES(kb) ((kb)*1024)
 #define MB_TO_BYTES(mb) ((mb)*1024 * 1024)
 

--- a/source/s3_auto_ranged_get.c
+++ b/source/s3_auto_ranged_get.c
@@ -148,6 +148,7 @@ static bool s_s3_auto_ranged_get_update(
     uint32_t flags,
     struct aws_s3_request **out_request) {
     AWS_PRECONDITION(meta_request);
+    AWS_PRECONDITION(out_request);
 
     struct aws_s3_auto_ranged_get *auto_ranged_get = meta_request->impl;
     struct aws_s3_request *request = NULL;
@@ -185,10 +186,6 @@ static bool s_s3_auto_ranged_get_update(
             bool head_object_required = auto_ranged_get->initial_message_has_range_header != 0;
 
             if (head_object_required) {
-                if (out_request == NULL) {
-                    goto has_work_remaining;
-                }
-
                 /* If the head object request hasn't been sent yet, then send it now. */
                 if (!auto_ranged_get->synced_data.head_object_sent) {
                     request = aws_s3_request_new(
@@ -203,11 +200,6 @@ static bool s_s3_auto_ranged_get_update(
                 }
 
             } else if (auto_ranged_get->synced_data.num_parts_requested == 0) {
-
-                if (out_request == NULL) {
-                    goto has_work_remaining;
-                }
-
                 /* If we aren't using a head object, then discover the size of the object while trying to get the first
                  * part. */
                 request = aws_s3_request_new(
@@ -236,11 +228,6 @@ static bool s_s3_auto_ranged_get_update(
                     goto has_work_remaining;
                 }
             }
-
-            if (out_request == NULL) {
-                goto has_work_remaining;
-            }
-
             request = aws_s3_request_new(
                 meta_request,
                 AWS_S3_AUTO_RANGE_GET_REQUEST_TYPE_INITIAL_MESSAGE,
@@ -252,10 +239,6 @@ static bool s_s3_auto_ranged_get_update(
         }
 
         if (auto_ranged_get->synced_data.num_parts_requested < auto_ranged_get->synced_data.total_num_parts) {
-            if (out_request == NULL) {
-                goto has_work_remaining;
-            }
-
             request = aws_s3_request_new(
                 meta_request,
                 AWS_S3_AUTO_RANGE_GET_REQUEST_TYPE_PART,
@@ -329,10 +312,7 @@ no_work_remaining:
     aws_s3_meta_request_unlock_synced_data(meta_request);
 
     if (work_remaining) {
-        if (request != NULL) {
-            AWS_ASSERT(out_request != NULL);
-            *out_request = request;
-        }
+        *out_request = request;
     } else {
         AWS_ASSERT(request == NULL);
         aws_s3_meta_request_finish(meta_request);

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -752,6 +752,11 @@ static struct aws_s3_meta_request *s_s3_client_meta_request_factory_default(
 
     /* Call the appropriate meta-request new function. */
     if (options->type == AWS_S3_META_REQUEST_TYPE_GET_OBJECT) {
+
+        if (aws_http_headers_has(initial_message_headers, aws_byte_cursor_from_c_str("partNumber"))) {
+            return aws_s3_meta_request_default_new(client->allocator, client, content_length, false, options);
+        }
+
         return aws_s3_meta_request_auto_ranged_get_new(client->allocator, client, client->part_size, options);
     } else if (options->type == AWS_S3_META_REQUEST_TYPE_PUT_OBJECT) {
 

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -753,6 +753,9 @@ static struct aws_s3_meta_request *s_s3_client_meta_request_factory_default(
     /* Call the appropriate meta-request new function. */
     if (options->type == AWS_S3_META_REQUEST_TYPE_GET_OBJECT) {
 
+        /* If the initial request already has partNumber, the request is not splittable(?). Treat it as a Default
+         * request.
+         * TODO: Still need tests to verify that the request of a part is splittable or not */
         if (aws_http_headers_has(initial_message_headers, aws_byte_cursor_from_c_str("partNumber"))) {
             return aws_s3_meta_request_default_new(client->allocator, client, content_length, false, options);
         }

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -114,8 +114,6 @@ int aws_s3_meta_request_init_base(
     meta_request->initial_request_message = options->message;
     aws_http_message_acquire(options->message);
 
-    aws_s3_add_user_agent_header(meta_request->allocator, meta_request->initial_request_message);
-
     if (aws_mutex_init(&meta_request->synced_data.lock)) {
         AWS_LOGF_ERROR(
             AWS_LS_S3_META_REQUEST, "id=%p Could not initialize mutex for meta request", (void *)meta_request);
@@ -437,6 +435,8 @@ static void s_s3_meta_request_prepare_request_task(struct aws_task *task, void *
     }
 
     ++request->num_times_prepared;
+
+    aws_s3_add_user_agent_header(meta_request->allocator, request->send_data.message);
 
     /* Sign the newly created message. */
     s_s3_meta_request_sign_request(meta_request, request, s_s3_meta_request_request_on_signed, payload);

--- a/tests/s3_data_plane_tests.c
+++ b/tests/s3_data_plane_tests.c
@@ -2761,9 +2761,10 @@ static int s_test_add_user_agent_header(struct aws_allocator *allocator, void *c
     return 0;
 }
 
-static int s_s3_test_user_agent_meta_request_prepare_request(
+static void s_s3_test_user_agent_meta_request_finished_request(
     struct aws_s3_meta_request *meta_request,
-    struct aws_s3_request *request) {
+    struct aws_s3_request *request,
+    int error_code) {
 
     AWS_ASSERT(meta_request != NULL);
 
@@ -2773,18 +2774,11 @@ static int s_s3_test_user_agent_meta_request_prepare_request(
     struct aws_s3_tester *tester = results->tester;
     AWS_ASSERT(tester != NULL);
 
-    struct aws_s3_meta_request_vtable *original_meta_request_vtable =
-        aws_s3_tester_get_meta_request_vtable_patch(tester, 0)->original_vtable;
-
-    if (original_meta_request_vtable->prepare_request(meta_request, request)) {
-        return AWS_OP_ERR;
-    }
-
     struct aws_byte_buf expected_user_agent_value_buf;
     s_get_expected_user_agent(meta_request->allocator, &expected_user_agent_value_buf);
 
     const struct aws_byte_cursor null_terminator = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("\0");
-    ASSERT_SUCCESS(aws_byte_buf_append_dynamic(&expected_user_agent_value_buf, &null_terminator));
+    AWS_ASSERT(aws_byte_buf_append_dynamic(&expected_user_agent_value_buf, &null_terminator) == AWS_OP_SUCCESS);
 
     struct aws_byte_cursor expected_user_agent_value = aws_byte_cursor_from_buf(&expected_user_agent_value_buf);
 
@@ -2794,18 +2788,21 @@ static int s_s3_test_user_agent_meta_request_prepare_request(
     struct aws_byte_cursor user_agent_value;
     AWS_ZERO_STRUCT(user_agent_value);
 
-    ASSERT_SUCCESS(aws_http_headers_get(headers, g_user_agent_header_name, &user_agent_value));
+    AWS_ASSERT(aws_http_headers_get(headers, g_user_agent_header_name, &user_agent_value) == AWS_OP_SUCCESS);
 
     const char *find_result = strstr((const char *)user_agent_value.ptr, (const char *)expected_user_agent_value.ptr);
 
-    ASSERT_TRUE(find_result != NULL);
-    ASSERT_TRUE(find_result < (const char *)(user_agent_value.ptr + user_agent_value.len));
-
+    AWS_ASSERT(find_result != NULL);
+    AWS_ASSERT(find_result < (const char *)(user_agent_value.ptr + user_agent_value.len));
     aws_byte_buf_clean_up(&expected_user_agent_value_buf);
-    return AWS_OP_SUCCESS;
+
+    struct aws_s3_meta_request_vtable *original_meta_request_vtable =
+        aws_s3_tester_get_meta_request_vtable_patch(tester, 0)->original_vtable;
+
+    original_meta_request_vtable->finished_request(meta_request, request, error_code);
 }
 
-static struct aws_s3_meta_request *s_s3_meta_request_factory_override_prepare_request(
+static struct aws_s3_meta_request *s_s3_meta_request_factory_override_finished_request(
     struct aws_s3_client *client,
     const struct aws_s3_meta_request_options *options) {
     AWS_ASSERT(client != NULL);
@@ -2820,7 +2817,7 @@ static struct aws_s3_meta_request *s_s3_meta_request_factory_override_prepare_re
 
     struct aws_s3_meta_request_vtable *patched_meta_request_vtable =
         aws_s3_tester_patch_meta_request_vtable(tester, meta_request, NULL);
-    patched_meta_request_vtable->prepare_request = s_s3_test_user_agent_meta_request_prepare_request;
+    patched_meta_request_vtable->finished_request = s_s3_test_user_agent_meta_request_finished_request;
 
     return meta_request;
 }
@@ -2834,7 +2831,7 @@ int s_s3_test_sending_user_agent_create_client(struct aws_s3_tester *tester, str
     ASSERT_SUCCESS(aws_s3_tester_client_new(tester, &client_options, client));
 
     struct aws_s3_client_vtable *patched_client_vtable = aws_s3_tester_patch_client_vtable(tester, *client, NULL);
-    patched_client_vtable->meta_request_factory = s_s3_meta_request_factory_override_prepare_request;
+    patched_client_vtable->meta_request_factory = s_s3_meta_request_factory_override_finished_request;
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/s3_data_plane_tests.c
+++ b/tests/s3_data_plane_tests.c
@@ -2777,9 +2777,6 @@ static void s_s3_test_user_agent_meta_request_finished_request(
     struct aws_byte_buf expected_user_agent_value_buf;
     s_get_expected_user_agent(meta_request->allocator, &expected_user_agent_value_buf);
 
-    const struct aws_byte_cursor null_terminator = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("\0");
-    AWS_ASSERT(aws_byte_buf_append_dynamic(&expected_user_agent_value_buf, &null_terminator) == AWS_OP_SUCCESS);
-
     struct aws_byte_cursor expected_user_agent_value = aws_byte_cursor_from_buf(&expected_user_agent_value_buf);
 
     struct aws_http_message *message = request->send_data.message;
@@ -2789,11 +2786,7 @@ static void s_s3_test_user_agent_meta_request_finished_request(
     AWS_ZERO_STRUCT(user_agent_value);
 
     AWS_ASSERT(aws_http_headers_get(headers, g_user_agent_header_name, &user_agent_value) == AWS_OP_SUCCESS);
-
-    const char *find_result = strstr((const char *)user_agent_value.ptr, (const char *)expected_user_agent_value.ptr);
-
-    AWS_ASSERT(find_result != NULL);
-    AWS_ASSERT(find_result < (const char *)(user_agent_value.ptr + user_agent_value.len));
+    AWS_ASSERT(aws_byte_cursor_eq(&user_agent_value, &expected_user_agent_value));
     aws_byte_buf_clean_up(&expected_user_agent_value_buf);
 
     struct aws_s3_meta_request_vtable *original_meta_request_vtable =


### PR DESCRIPTION
*Description of changes:*
* Improving ASSERT_SYNCED_DATA_LOCK_HELD
* Taking out null checks for out_request, which should no longer be necessary.
* Falling back to default meta request for a request of a part, as I don't believe this is splittable. Still needs a corresponding test.
* Adding user agent header in the prepare instead of modifying the original request. Tests may be failing because of the way they are overriding the prepare_request virtual function, which only overrides some of the virtual function behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
