### PR TITLE
update max part size

### DIFF
--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -64,7 +64,8 @@ const uint32_t g_max_num_connections_per_vip = 10;
  * Default part size is 8 MB to reach the best performance from the experiments we had.
  * Default max part size is SIZE_MAX at 32bit build, which is around 4GB, which is 5GB at 64bit build.
  *      The server limit is 5GB, but object size limit is 5TB for now. We should be good enough for all the case.
- *      For upload, the max number of parts is 10000, which will limits the object size to 40 TB.
+ *      For upload, the max number of parts is 10000, which will limits the object size to 40TB for 32bit and 50TB for
+ *      64bit.
  * TODO Provide more information on other values.
  */
 static const size_t s_default_part_size = 8 * 1024 * 1024;

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -60,11 +60,11 @@ const uint32_t g_num_conns_per_vip_meta_request_look_up[AWS_S3_META_REQUEST_TYPE
 /* Should be max of s_num_conns_per_vip_meta_request_look_up */
 const uint32_t g_max_num_connections_per_vip = 10;
 
-/* TODO Provide more information on these values. */
 /**
  * Default part size is 8 MB to reach the best performance from the experiments we had.
  * Default max part size it 5 GB, which is the limit from service side.
  *      For upload, the max number of parts is 10000, which will limits the object size to 50 TB.
+ * TODO Provide more information on other values.
  */
 static const size_t s_default_part_size = 8 * 1024 * 1024;
 static const size_t s_default_max_part_size = 5 * 1024 * 1024 * 1024;

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -62,13 +62,13 @@ const uint32_t g_max_num_connections_per_vip = 10;
 
 /**
  * Default part size is 8 MB to reach the best performance from the experiments we had.
- * Default max part size it SIZE_MAX, which is around 4GB.
+ * Default max part size is SIZE_MAX at 32bit build, which is around 4GB, which is 5GB at 64bit build.
  *      The server limit is 5GB, but object size limit is 5TB for now. We should be good enough for all the case.
  *      For upload, the max number of parts is 10000, which will limits the object size to 40 TB.
  * TODO Provide more information on other values.
  */
 static const size_t s_default_part_size = 8 * 1024 * 1024;
-static const size_t s_default_max_part_size = SIZE_MAX;
+static const size_t s_default_max_part_size = SIZE_MAX < 5000000000000ULL ? SIZE_MAX : 5000000000000ULL;
 static const double s_default_throughput_target_gbps = 10.0;
 static const uint32_t s_default_max_retries = 5;
 static size_t s_dns_host_address_ttl_seconds = 5 * 60;

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -781,7 +781,7 @@ static struct aws_s3_meta_request *s_s3_client_meta_request_factory_default(
         size_t client_max_part_size = client->max_part_size;
 
         if (client_part_size < g_s3_min_upload_part_size) {
-            AWS_LOGF_ERROR(
+            AWS_LOGF_WARN(
                 AWS_LS_S3_META_REQUEST,
                 "Client config part size of %" PRIu64 " is less than the minimum upload part size of %" PRIu64
                 ". Using to the minimum part-size for upload.",
@@ -792,7 +792,7 @@ static struct aws_s3_meta_request *s_s3_client_meta_request_factory_default(
         }
 
         if (client_max_part_size < g_s3_min_upload_part_size) {
-            AWS_LOGF_ERROR(
+            AWS_LOGF_WARN(
                 AWS_LS_S3_META_REQUEST,
                 "Client config max part size of %" PRIu64 " is less than the minimum upload part size of %" PRIu64
                 ". Clamping to the minimum part-size for upload.",

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -62,12 +62,13 @@ const uint32_t g_max_num_connections_per_vip = 10;
 
 /**
  * Default part size is 8 MB to reach the best performance from the experiments we had.
- * Default max part size it 5 GB, which is the limit from service side.
- *      For upload, the max number of parts is 10000, which will limits the object size to 50 TB.
+ * Default max part size it SIZE_MAX, which is around 4GB.
+ *      The server limit is 5GB, but object size limit is 5TB for now. We should be good enough for all the case.
+ *      For upload, the max number of parts is 10000, which will limits the object size to 40 TB.
  * TODO Provide more information on other values.
  */
 static const size_t s_default_part_size = 8 * 1024 * 1024;
-static const size_t s_default_max_part_size = 5 * 1024 * 1024 * 1024;
+static const size_t s_default_max_part_size = SIZE_MAX;
 static const double s_default_throughput_target_gbps = 10.0;
 static const uint32_t s_default_max_retries = 5;
 static size_t s_dns_host_address_ttl_seconds = 5 * 60;

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -61,8 +61,13 @@ const uint32_t g_num_conns_per_vip_meta_request_look_up[AWS_S3_META_REQUEST_TYPE
 const uint32_t g_max_num_connections_per_vip = 10;
 
 /* TODO Provide more information on these values. */
+/**
+ * Default part size is 8 MB to reach the best performance from the experiments we had.
+ * Default max part size it 5 GB, which is the limit from service side.
+ *      For upload, the max number of parts is 10000, which will limits the object size to 50 TB.
+ */
 static const size_t s_default_part_size = 8 * 1024 * 1024;
-static const size_t s_default_max_part_size = 32 * 1024 * 1024;
+static const size_t s_default_max_part_size = 5 * 1024 * 1024 * 1024;
 static const double s_default_throughput_target_gbps = 10.0;
 static const uint32_t s_default_max_retries = 5;
 static size_t s_dns_host_address_ttl_seconds = 5 * 60;


### PR DESCRIPTION
*Issue #, if available:*

- Seems meaningless to set 32MB max part size 

*Description of changes:*

- Update the max part size to 4GB, as SIZE_MAX. The server side limit is https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
