### PR TITLE
Add CopyObject progress callback and update cli sample

### DIFF
--- a/include/aws/s3/private/s3_meta_request_impl.h
+++ b/include/aws/s3/private/s3_meta_request_impl.h
@@ -127,6 +127,7 @@ struct aws_s3_meta_request {
     aws_s3_meta_request_receive_body_callback_fn *body_callback;
     aws_s3_meta_request_finish_fn *finish_callback;
     aws_s3_meta_request_shutdown_fn *shutdown_callback;
+    aws_s3_meta_request_progress_fn *progress_callback;
 
     enum aws_s3_meta_request_type type;
 

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -229,7 +229,9 @@ struct aws_s3_meta_request_options {
     aws_s3_meta_request_shutdown_fn *shutdown_callback;
 
     /**
-     * Invoked to report progress of multi-part upload and copy object requests.
+     * Invoked to report progress of the meta request execution.
+     * Currently, the progress callback is invoked only for the CopyObject meta request type.
+     * TODO: support this callback for all the types of meta requests
      * See `aws_s3_meta_request_progress_fn`
      */
     aws_s3_meta_request_progress_fn *progress_callback;

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -82,6 +82,7 @@ typedef int(aws_s3_meta_request_headers_callback_fn)(
  * Return AWS_OP_ERR to indicate failure and cancel the request.
  */
 typedef int(aws_s3_meta_request_receive_body_callback_fn)(
+
     /* The meta request that the callback is being issued for. */
     struct aws_s3_meta_request *meta_request,
 
@@ -101,6 +102,26 @@ typedef int(aws_s3_meta_request_receive_body_callback_fn)(
 typedef void(aws_s3_meta_request_finish_fn)(
     struct aws_s3_meta_request *meta_request,
     const struct aws_s3_meta_request_result *meta_request_result,
+    void *user_data);
+
+/**
+ * Information sent in the meta_request progress callback.
+ */
+struct aws_s3_meta_request_progress {
+
+    /* Bytes transferred since the previous progress update */
+    uint64_t bytes_transferred;
+
+    /* Length of the entire meta request operation */
+    uint64_t content_length;
+};
+
+/**
+ * Invoked to report progress of multi-part upload and copy object requests.
+ */
+typedef void(aws_s3_meta_request_progress_fn)(
+    struct aws_s3_meta_request *meta_request,
+    const struct aws_s3_meta_request_progress *progress,
     void *user_data);
 
 typedef void(aws_s3_meta_request_shutdown_fn)(void *user_data);
@@ -206,6 +227,12 @@ struct aws_s3_meta_request_options {
 
     /* Callback for when the meta request has completely cleaned up. */
     aws_s3_meta_request_shutdown_fn *shutdown_callback;
+
+    /**
+     * Invoked to report progress of multi-part upload and copy object requests.
+     * See `aws_s3_meta_request_progress_fn`
+     */
+    aws_s3_meta_request_progress_fn *progress_callback;
 };
 
 /* Result details of a meta request.

--- a/samples/s3/cli_progress_bar.c
+++ b/samples/s3/cli_progress_bar.c
@@ -177,6 +177,13 @@ void progress_listener_reset_progress(struct progress_listener *listener) {
     aws_mutex_unlock(&listener->mutex);
 }
 
+void progress_listener_update_max_value(struct progress_listener *listener, uint64_t max_value) {
+    aws_mutex_lock(&listener->mutex);
+    listener->max = max_value;
+    listener->render_update_pending = true;
+    aws_mutex_unlock(&listener->mutex);
+}
+
 void progress_listener_update_state(struct progress_listener *listener, struct aws_string *state_name) {
     aws_mutex_lock(&listener->mutex);
     aws_string_destroy(listener->state);

--- a/samples/s3/cli_progress_bar.h
+++ b/samples/s3/cli_progress_bar.h
@@ -63,6 +63,8 @@ void progress_listener_update_progress(struct progress_listener *listener, uint6
 
 void progress_listener_reset_progress(struct progress_listener *listener);
 
+void progress_listener_update_max_value(struct progress_listener *listener, uint64_t max_value);
+
 /**
  * Update the label for the progress bar.
  */

--- a/samples/s3/s3-cp.c
+++ b/samples/s3/s3-cp.c
@@ -359,7 +359,7 @@ static void s_copy_object_request_finish(
     struct aws_string *new_state = NULL;
     if (meta_request_result->error_code == AWS_ERROR_SUCCESS) {
         new_state = aws_string_new_from_c_str(transfer_ctx->cp_app_ctx->app_ctx->allocator, "Completed");
-        progress_listener_update_progress(transfer_ctx->listener, 1000);
+        progress_listener_update_progress(transfer_ctx->listener, 100);
     } else {
         new_state = aws_string_new_from_c_str(transfer_ctx->cp_app_ctx->app_ctx->allocator, "Error");
     }

--- a/source/s3_copy_object.c
+++ b/source/s3_copy_object.c
@@ -540,6 +540,37 @@ message_create_failed:
     return AWS_OP_ERR;
 }
 
+/* For UploadPartCopy requests, etag is sent in the request body, within XML entity quotes */
+static struct aws_string *s_get_etag_from_upload_part_copy_response(
+    struct aws_allocator *allocator,
+    struct aws_byte_buf *response_body) {
+    struct aws_string *etag = NULL;
+
+    struct aws_byte_cursor response_body_cursor = aws_byte_cursor_from_buf(response_body);
+
+    struct aws_string *etag_within_xml_quotes =
+        get_top_level_xml_tag_value(allocator, &g_etag_header_name, &response_body_cursor);
+
+    struct aws_byte_buf etag_within_quotes_byte_buf;
+    AWS_ZERO_STRUCT(etag_within_quotes_byte_buf);
+    replace_quote_entities(allocator, etag_within_xml_quotes, &etag_within_quotes_byte_buf);
+
+    /* Remove the quotes surrounding the etag. */
+    struct aws_byte_cursor etag_within_quotes_byte_cursor = aws_byte_cursor_from_buf(&etag_within_quotes_byte_buf);
+    if (etag_within_quotes_byte_cursor.len >= 2 && etag_within_quotes_byte_cursor.ptr[0] == '"' &&
+        etag_within_quotes_byte_cursor.ptr[etag_within_quotes_byte_cursor.len - 1] == '"') {
+
+        aws_byte_cursor_advance(&etag_within_quotes_byte_cursor, 1);
+        --etag_within_quotes_byte_cursor.len;
+    }
+
+    etag = aws_string_new_from_cursor(allocator, &etag_within_quotes_byte_cursor);
+    aws_byte_buf_clean_up(&etag_within_quotes_byte_buf);
+    aws_string_destroy(etag_within_xml_quotes);
+
+    return etag;
+}
+
 static void s_s3_copy_object_request_finished(
     struct aws_s3_meta_request *meta_request,
     struct aws_s3_request *request,
@@ -646,34 +677,6 @@ static void s_s3_copy_object_request_finished(
             size_t part_number = request->part_number;
             AWS_FATAL_ASSERT(part_number > 0);
             size_t part_index = part_number - 1;
-            struct aws_string *etag = NULL;
-
-            if (error_code == AWS_ERROR_SUCCESS) {
-                /* For UploadPartCopy requests, etag is sent in the request body, within XML entity quotes */
-                struct aws_byte_cursor response_body_cursor =
-                    aws_byte_cursor_from_buf(&request->send_data.response_body);
-
-                struct aws_string *etag_within_xml_quotes =
-                    get_top_level_xml_tag_value(meta_request->allocator, &g_etag_header_name, &response_body_cursor);
-
-                struct aws_byte_buf etag_within_quotes_byte_buf;
-                AWS_ZERO_STRUCT(etag_within_quotes_byte_buf);
-                replace_quote_entities(meta_request->allocator, etag_within_xml_quotes, &etag_within_quotes_byte_buf);
-
-                /* Remove the quotes surrounding the etag. */
-                struct aws_byte_cursor etag_within_quotes_byte_cursor =
-                    aws_byte_cursor_from_buf(&etag_within_quotes_byte_buf);
-                if (etag_within_quotes_byte_cursor.len >= 2 && etag_within_quotes_byte_cursor.ptr[0] == '"' &&
-                    etag_within_quotes_byte_cursor.ptr[etag_within_quotes_byte_cursor.len - 1] == '"') {
-
-                    aws_byte_cursor_advance(&etag_within_quotes_byte_cursor, 1);
-                    --etag_within_quotes_byte_cursor.len;
-                }
-
-                etag = aws_string_new_from_cursor(meta_request->allocator, &etag_within_quotes_byte_cursor);
-                aws_byte_buf_clean_up(&etag_within_quotes_byte_buf);
-                aws_string_destroy(etag_within_xml_quotes);
-            }
 
             ++copy_object->synced_data.num_parts_completed;
 
@@ -685,12 +688,20 @@ static void s_s3_copy_object_request_finished(
                 copy_object->synced_data.total_num_parts);
 
             if (error_code == AWS_ERROR_SUCCESS) {
+                struct aws_string *etag = s_get_etag_from_upload_part_copy_response(
+                    meta_request->allocator, &request->send_data.response_body);
+
                 AWS_ASSERT(etag != NULL);
 
                 ++copy_object->synced_data.num_parts_successful;
+                if (meta_request->progress_callback != NULL) {
+                    struct aws_s3_meta_request_progress progress = {
+                        .bytes_transferred = copy_object->synced_data.part_size,
+                        .content_length = copy_object->synced_data.content_length};
+                    meta_request->progress_callback(meta_request, &progress, meta_request->user_data);
+                }
 
                 struct aws_string *null_etag = NULL;
-
                 /* ETags need to be associated with their part number, so we keep the etag indices consistent with
                  * part numbers. This means we may have to add padding to the list in the case that parts finish out
                  * of order. */
@@ -698,7 +709,6 @@ static void s_s3_copy_object_request_finished(
                     int push_back_result = aws_array_list_push_back(&copy_object->synced_data.etag_list, &null_etag);
                     AWS_FATAL_ASSERT(push_back_result == AWS_OP_SUCCESS);
                 }
-
                 aws_array_list_set_at(&copy_object->synced_data.etag_list, &etag, part_index);
             } else {
                 ++copy_object->synced_data.num_parts_failed;

--- a/source/s3_copy_object.c
+++ b/source/s3_copy_object.c
@@ -541,7 +541,7 @@ message_create_failed:
 }
 
 /* For UploadPartCopy requests, etag is sent in the request body, within XML entity quotes */
-static struct aws_string *s_get_etag_from_upload_part_copy_response(
+static struct aws_string *s_etag_new_from_upload_part_copy_response(
     struct aws_allocator *allocator,
     struct aws_byte_buf *response_body) {
     struct aws_string *etag = NULL;
@@ -688,7 +688,7 @@ static void s_s3_copy_object_request_finished(
                 copy_object->synced_data.total_num_parts);
 
             if (error_code == AWS_ERROR_SUCCESS) {
-                struct aws_string *etag = s_get_etag_from_upload_part_copy_response(
+                struct aws_string *etag = s_etag_new_from_upload_part_copy_response(
                     meta_request->allocator, &request->send_data.response_body);
 
                 AWS_ASSERT(etag != NULL);

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -141,6 +141,7 @@ int aws_s3_meta_request_init_base(
     meta_request->body_callback = options->body_callback;
     meta_request->finish_callback = options->finish_callback;
     meta_request->shutdown_callback = options->shutdown_callback;
+    meta_request->progress_callback = options->progress_callback;
 
     return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Added progress callback for CopyObject meta requests
* Updated CLI sample to show the s3 to s3 copy in the progress bar
* Refactored the code to extract the `etag` from UploadPartCopy response into a distinct function

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
