### PR TITLE
UploadPartCopy requests should not use Content-MD5

### DIFF
--- a/source/s3_copy_object.c
+++ b/source/s3_copy_object.c
@@ -48,23 +48,6 @@ static struct aws_s3_meta_request_vtable s_s3_copy_object_vtable = {
     .finish = aws_s3_meta_request_finish_default,
 };
 
-static bool s_should_compute_content_md5(struct aws_s3_client *client, struct aws_http_message *message) {
-
-    AWS_PRECONDITION(client);
-    AWS_PRECONDITION(message);
-
-    if (client->compute_content_md5 == AWS_MR_CONTENT_MD5_ENABLED) {
-        return true;
-    }
-
-    struct aws_http_headers *headers = aws_http_message_get_headers(message);
-    if (aws_http_headers_has(headers, g_content_md5_header_name)) {
-        return true;
-    }
-
-    return false;
-}
-
 /* Allocate a new copy object meta request */
 struct aws_s3_meta_request *aws_s3_meta_request_copy_object_new(
     struct aws_allocator *allocator,
@@ -88,7 +71,7 @@ struct aws_s3_meta_request *aws_s3_meta_request_copy_object_new(
             allocator,
             client,
             UNKNOWN_PART_SIZE,
-            s_should_compute_content_md5(client, options->message),
+            false,
             options,
             copy_object,
             &s_s3_copy_object_vtable,


### PR DESCRIPTION
The Content-MD5 header is not supported in UploadPartCopy
requests. This commit removes the logic that would compute
Content-MD5 when it was included in the meta request.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
