### PR TITLE
s3_client: treat user-configured and internal retry strategies in the same way

### DIFF
--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -387,7 +387,6 @@ struct aws_s3_client *aws_s3_client_new(
     client->synced_data.active = true;
 
     if (client_config->retry_strategy != NULL) {
-        aws_retry_strategy_acquire(client_config->retry_strategy);
         client->retry_strategy = client_config->retry_strategy;
     } else {
         struct aws_exponential_backoff_retry_options backoff_retry_options = {


### PR DESCRIPTION
*Issue #, if available:*
Resolves #176.

*Description of changes:*
A client-configured `retry_strategy` starts with a reference count of 1, and is supposed to be released upon client destruction.
However, due to acquiring an additional reference in `aws_s3_client_new`, the client `retry_strategy` is never released, causing the code to hang.

Fixed by treating internal and client-configured retry strategies in  the same way.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
