### PR TITLE
Invoke headers callback when CopyObject request is bypassed

### DIFF
--- a/source/s3_copy_object.c
+++ b/source/s3_copy_object.c
@@ -594,8 +594,32 @@ static void s_s3_copy_object_request_finished(
             break;
         }
 
+        /* The S3 object is not large enough for multi-part copy. A copy of the original CopyObject request
+         * was bypassed to S3 and is now finished. */
         case AWS_S3_COPY_OBJECT_REQUEST_TAG_BYPASS: {
 
+            /* Invoke headers callback if it was requested for this meta request */
+            if (meta_request->headers_callback != NULL) {
+                struct aws_http_headers *final_response_headers = aws_http_headers_new(meta_request->allocator);
+
+                /* Copy all the response headers from this request. */
+                copy_http_headers(request->send_data.response_headers, final_response_headers);
+
+                /* Notify the user of the headers. */
+                if (meta_request->headers_callback(
+                        meta_request,
+                        final_response_headers,
+                        request->send_data.response_status,
+                        meta_request->user_data)) {
+
+                    error_code = aws_last_error_or_unknown();
+                }
+                meta_request->headers_callback = NULL;
+
+                aws_http_headers_release(final_response_headers);
+            }
+
+            /* Signals completion of the meta request */
             if (error_code == AWS_ERROR_SUCCESS) {
                 copy_object->synced_data.copy_request_bypass_completed = true;
             } else {
@@ -744,6 +768,7 @@ static void s_s3_copy_object_request_finished(
 
                     error_code = aws_last_error_or_unknown();
                 }
+                meta_request->headers_callback = NULL;
 
                 aws_http_headers_release(final_response_headers);
             }

--- a/tests/s3_data_plane_tests.c
+++ b/tests/s3_data_plane_tests.c
@@ -3535,6 +3535,10 @@ static int s_copy_object_meta_request_headers_callback(
     int response_status,
     void *user_data) {
 
+    (void)meta_request;
+    (void)headers;
+    (void)response_status;
+
     struct copy_object_test_data *test_data = user_data;
 
     aws_mutex_lock(&test_data->mutex);


### PR DESCRIPTION
Prior to this fix the headers callback was invoked only
when the Copy meta request performed a multi-part copy, but not
when the object was small and resulted in a bypassed CopyObject request.

This commit fixes the issue, invoking the headers callback
in both cases.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
