### PR TITLE
Don't re-send "x-amz-meta-" headers in each part of a multipart upload.

### DIFF
--- a/include/aws/s3/private/s3_request_messages.h
+++ b/include/aws/s3/private/s3_request_messages.h
@@ -21,11 +21,17 @@ struct aws_array_list;
 AWS_EXTERN_C_BEGIN
 
 AWS_S3_API
-struct aws_http_message *aws_s3_message_util_copy_http_message_no_body(
+struct aws_http_message *aws_s3_message_util_copy_http_message_no_body_all_headers(
+    struct aws_allocator *allocator,
+    struct aws_http_message *message);
+
+AWS_S3_API
+struct aws_http_message *aws_s3_message_util_copy_http_message_no_body_filter_headers(
     struct aws_allocator *allocator,
     struct aws_http_message *message,
     const struct aws_byte_cursor *excluded_headers_arrays,
-    size_t excluded_headers_size);
+    size_t excluded_headers_size,
+    bool exclude_x_amz_meta);
 
 AWS_S3_API
 struct aws_input_stream *aws_s3_message_util_assign_body(

--- a/include/aws/s3/private/s3_request_messages.h
+++ b/include/aws/s3/private/s3_request_messages.h
@@ -20,11 +20,14 @@ struct aws_array_list;
 
 AWS_EXTERN_C_BEGIN
 
+/* Copy message (but not the body) and retain all headers */
 AWS_S3_API
 struct aws_http_message *aws_s3_message_util_copy_http_message_no_body_all_headers(
     struct aws_allocator *allocator,
     struct aws_http_message *message);
 
+/* Copy mesage (but not the body) and exclude specific headers.
+ * exclude_x_amz_meta controls whether S3 user metadata headers (prefixed with "x-amz-meta) are excluded.*/
 AWS_S3_API
 struct aws_http_message *aws_s3_message_util_copy_http_message_no_body_filter_headers(
     struct aws_allocator *allocator,

--- a/source/s3_auto_ranged_get.c
+++ b/source/s3_auto_ranged_get.c
@@ -316,8 +316,8 @@ static int s_s3_auto_ranged_get_prepare_request(
     switch (request->request_tag) {
         case AWS_S3_AUTO_RANGE_GET_REQUEST_TYPE_HEAD_OBJECT:
             /* A head object will be a copy of the original headers but with a HEAD request method. */
-            message = aws_s3_message_util_copy_http_message_no_body(
-                meta_request->allocator, meta_request->initial_request_message, NULL, 0);
+            message = aws_s3_message_util_copy_http_message_no_body_all_headers(
+                meta_request->allocator, meta_request->initial_request_message);
             aws_http_message_set_request_method(message, g_head_method);
             break;
         case AWS_S3_AUTO_RANGE_GET_REQUEST_TYPE_PART:
@@ -328,8 +328,8 @@ static int s_s3_auto_ranged_get_prepare_request(
                 request->part_range_end);
             break;
         case AWS_S3_AUTO_RANGE_GET_REQUEST_TYPE_INITIAL_MESSAGE:
-            message = aws_s3_message_util_copy_http_message_no_body(
-                meta_request->allocator, meta_request->initial_request_message, NULL, 0);
+            message = aws_s3_message_util_copy_http_message_no_body_all_headers(
+                meta_request->allocator, meta_request->initial_request_message);
             break;
     }
 

--- a/source/s3_copy_object.c
+++ b/source/s3_copy_object.c
@@ -361,8 +361,8 @@ static int s_s3_copy_object_prepare_request(struct aws_s3_meta_request *meta_req
         /* The S3 object is not large enough for multi-part copy. Bypasses a copy of the original CopyObject request to
          * S3. */
         case AWS_S3_COPY_OBJECT_REQUEST_TAG_BYPASS: {
-            message = aws_s3_message_util_copy_http_message_no_body(
-                meta_request->allocator, meta_request->initial_request_message, NULL, 0);
+            message = aws_s3_message_util_copy_http_message_no_body_all_headers(
+                meta_request->allocator, meta_request->initial_request_message);
             break;
         }
 

--- a/source/s3_default_meta_request.c
+++ b/source/s3_default_meta_request.c
@@ -241,8 +241,8 @@ static int s_s3_meta_request_default_prepare_request(
         }
     }
 
-    struct aws_http_message *message = aws_s3_message_util_copy_http_message_no_body(
-        meta_request->allocator, meta_request->initial_request_message, NULL, 0);
+    struct aws_http_message *message = aws_s3_message_util_copy_http_message_no_body_all_headers(
+        meta_request->allocator, meta_request->initial_request_message);
 
     const enum aws_s3_checksum_algorithm checksum_algorithm = meta_request->checksum_algorithm;
     if (!checksum_algorithm && meta_request->should_compute_content_md5) {

--- a/source/s3_request_messages.c
+++ b/source/s3_request_messages.c
@@ -171,7 +171,10 @@ struct aws_http_message *aws_s3_create_multipart_upload_message_new(
     enum aws_s3_checksum_algorithm algorithm) {
     AWS_PRECONDITION(allocator);
 
-    /* For multipart upload, sse related headers should only be shown in create-multipart request */
+    /* For multipart upload, some headers should ONLY be in the initial create-multipart request.
+     * Headers such as:
+     * - SSE related headers
+     * - user metadata (prefixed "x-amz-meta-") headers */
     struct aws_http_message *message = aws_s3_message_util_copy_http_message_no_body_filter_headers(
         allocator,
         base_message,


### PR DESCRIPTION
**Issue:**
Multipart uploads with [user defined metadata](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html#UserMetadata) ("x-amz-meta-" headers) would fail due to these headers being repeated in each individual part that was uploaded. 

**Description of Changes:**
Filter "x-amz-meta-" headers out of any multipart upload request that isn't the initial "start" request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
