### PR TITLE
use aws_byte_cursor_utf8_parse_u64

### DIFF
--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -758,13 +758,9 @@ static struct aws_s3_meta_request *s_s3_client_meta_request_factory_default(
     bool content_length_header_found = false;
 
     if (!aws_http_headers_get(initial_message_headers, g_content_length_header_name, &content_length_cursor)) {
-        struct aws_string *content_length_str = aws_string_new_from_cursor(client->allocator, &content_length_cursor);
-        char *content_length_str_end = NULL;
-
-        content_length = strtoull((const char *)content_length_str->bytes, &content_length_str_end, 10);
-        aws_string_destroy(content_length_str);
-
-        content_length_str = NULL;
+        if (aws_byte_cursor_utf8_parse_u64(content_length_cursor, &content_length)) {
+            return NULL;
+        }
         content_length_header_found = true;
     }
 

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -134,7 +134,7 @@ void aws_s3_set_dns_ttl(size_t ttl) {
  * When meta request is NULL, this will return the overall allowed number of connections.
  *
  * If meta_request is not NULL, this will give the max number of connections allowed for that meta request type on
- * thatendpoint.
+ * that endpoint.
  */
 uint32_t aws_s3_client_get_max_active_connections(
     struct aws_s3_client *client,

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -759,6 +759,11 @@ static struct aws_s3_meta_request *s_s3_client_meta_request_factory_default(
 
     if (!aws_http_headers_get(initial_message_headers, g_content_length_header_name, &content_length_cursor)) {
         if (aws_byte_cursor_utf8_parse_u64(content_length_cursor, &content_length)) {
+            AWS_LOGF_ERROR(
+                AWS_LS_S3_META_REQUEST,
+                "Could not parse Content-Length header. header value is:" PRInSTR "",
+                AWS_BYTE_CURSOR_PRI(content_length_cursor));
+            aws_raise_error(AWS_ERROR_S3_INVALID_CONTENT_LENGTH_HEADER);
             return NULL;
         }
         content_length_header_found = true;

--- a/source/s3_list_objects.c
+++ b/source/s3_list_objects.c
@@ -84,9 +84,9 @@ static bool s_on_contents_node(struct aws_xml_parser *parser, struct aws_xml_nod
         struct aws_byte_cursor size_cur;
 
         if (aws_xml_node_as_body(parser, node, &size_cur) == AWS_OP_SUCCESS) {
-            struct aws_string *size_str = aws_string_new_from_cursor(fs_wrapper->allocator, &size_cur);
-            fs_info->size = strtoull((const char *)size_str->bytes, NULL, 10);
-            aws_string_destroy(size_str);
+            if (aws_byte_cursor_utf8_parse_u64(size_cur, &fs_info->size)) {
+                return false;
+            }
             return true;
         }
     }

--- a/source/s3_list_parts.c
+++ b/source/s3_list_parts.c
@@ -80,9 +80,9 @@ static bool s_on_parts_node(struct aws_xml_parser *parser, struct aws_xml_node *
         struct aws_byte_cursor size_cur;
 
         if (aws_xml_node_as_body(parser, node, &size_cur) == AWS_OP_SUCCESS) {
-            struct aws_string *size_str = aws_string_new_from_cursor(result_wrapper->allocator, &size_cur);
-            part_info->size = strtoull((const char *)size_str->bytes, NULL, 10);
-            aws_string_destroy(size_str);
+            if (aws_byte_cursor_utf8_parse_u64(size_cur, &part_info->size)) {
+                return false;
+            }
             return true;
         }
     }
@@ -96,6 +96,7 @@ static bool s_on_parts_node(struct aws_xml_parser *parser, struct aws_xml_node *
                 return false;
             }
             if (part_number > UINT32_MAX) {
+                aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
                 return false;
             }
             part_info->part_number = (uint32_t)part_number;

--- a/source/s3_list_parts.c
+++ b/source/s3_list_parts.c
@@ -91,10 +91,14 @@ static bool s_on_parts_node(struct aws_xml_parser *parser, struct aws_xml_node *
         struct aws_byte_cursor part_number_cur;
 
         if (aws_xml_node_as_body(parser, node, &part_number_cur) == AWS_OP_SUCCESS) {
-            struct aws_string *part_number_str =
-                aws_string_new_from_cursor(result_wrapper->allocator, &part_number_cur);
-            part_info->part_number = strtoul((const char *)part_number_str->bytes, NULL, 10);
-            aws_string_destroy(part_number_str);
+            uint64_t part_number = 0;
+            if (aws_byte_cursor_utf8_parse_u64(part_number_cur, &part_number)) {
+                return false;
+            }
+            if (part_number > UINT32_MAX) {
+                return false;
+            }
+            part_info->part_number = (uint32_t)part_number;
             return true;
         }
     }


### PR DESCRIPTION
Replace `strtoull` with `aws_byte_cursor_utf8_parse_u64`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
