### PR TITLE
s3_endpoint: log ID of new connection_manager instead of nil

### DIFF
--- a/source/s3_endpoint.c
+++ b/source/s3_endpoint.c
@@ -191,7 +191,7 @@ static struct aws_http_connection_manager *s_s3_endpoint_create_http_connection_
         AWS_LS_S3_ENDPOINT,
         "id=%p: Created connection manager %p for endpoint",
         (void *)endpoint,
-        (void *)endpoint->http_connection_manager);
+        (void *)http_connection_manager);
 
     return http_connection_manager;
 }


### PR DESCRIPTION
Due to the way the function is called, `endpoint->http_connection_manager` is always `NULL` here, since nothing has been assigned yet.

Hence the log statement consistently prints `nil`, as in
```
[DEBUG] 2022-08-19 12:19:06.073 S3Endpoint [140627654626880] id=0x7fe63ff2b8e0: Created connection manager (nil) for endpoint
```
The absence of the ID makes it hard to trace problems in allocating/releasing the `http_connection_manager`.
Print its address instead, consistent with other output.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
