### PR TITLE
Fix race condition in aws_s3_client_endpoint_release (#202)

### DIFF
--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -32,7 +32,7 @@ enum aws_s3_connection_finish_code {
 };
 
 /* Callback for the owner of the endpoint when the endpoint has completely cleaned up. */
-typedef void(aws_s3_endpoint_shutdown_fn)(void *user_data);
+typedef void(aws_s3_endpoint_shutdown_fn)(struct aws_string *host_name, void *user_data);
 
 struct aws_s3_endpoint_options {
     /* URL of the host that this endpoint refers to. */
@@ -75,10 +75,6 @@ struct aws_s3_endpoint {
 
     /* Callback for when this endpoint completely shuts down. */
     aws_s3_endpoint_shutdown_fn *shutdown_callback;
-
-    /* True, if the endpoint is created by client. So, it need to be thread safe to manage the refcount via
-     * `aws_s3_client_endpoint_release` */
-    bool handled_by_client;
 
     void *user_data;
 };
@@ -313,11 +309,6 @@ struct aws_s3_endpoint *aws_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint
 
 AWS_S3_API
 void aws_s3_endpoint_release(struct aws_s3_endpoint *endpoint);
-
-/* If the endpoint is created by s3 client, it will be managed by the client via a hash table that need to be protected
- * by lock. A lock will be acquired within the call, never invoke with lock held */
-AWS_S3_API
-void aws_s3_client_endpoint_release(struct aws_s3_client *client, struct aws_s3_endpoint *endpoint);
 
 AWS_S3_API
 extern const uint32_t g_max_num_connections_per_vip;

--- a/source/s3_endpoint.c
+++ b/source/s3_endpoint.c
@@ -224,11 +224,11 @@ void aws_s3_client_endpoint_release(struct aws_s3_client *client, struct aws_s3_
         if (aws_atomic_load_int(&endpoint->ref_count.ref_count) == 1) {
             aws_hash_table_remove(&client->synced_data.endpoints, endpoint->host_name, NULL, NULL);
         }
-        aws_ref_count_release(&endpoint->ref_count);
-
         aws_s3_client_unlock_synced_data(client);
     }
     /* END CRITICAL SECTION */
+
+    aws_ref_count_release(&endpoint->ref_count);
 }
 
 static void s_s3_endpoint_ref_count_zero(void *user_data) {

--- a/source/s3_endpoint.c
+++ b/source/s3_endpoint.c
@@ -212,25 +212,6 @@ void aws_s3_endpoint_release(struct aws_s3_endpoint *endpoint) {
     aws_ref_count_release(&endpoint->ref_count);
 }
 
-void aws_s3_client_endpoint_release(struct aws_s3_client *client, struct aws_s3_endpoint *endpoint) {
-    AWS_PRECONDITION(endpoint);
-    AWS_PRECONDITION(client);
-    AWS_PRECONDITION(endpoint->handled_by_client);
-
-    /* BEGIN CRITICAL SECTION */
-    {
-        aws_s3_client_lock_synced_data(client);
-        /* The last refcount to release */
-        if (aws_atomic_load_int(&endpoint->ref_count.ref_count) == 1) {
-            aws_hash_table_remove(&client->synced_data.endpoints, endpoint->host_name, NULL, NULL);
-        }
-        aws_s3_client_unlock_synced_data(client);
-    }
-    /* END CRITICAL SECTION */
-
-    aws_ref_count_release(&endpoint->ref_count);
-}
-
 static void s_s3_endpoint_ref_count_zero(void *user_data) {
     struct aws_s3_endpoint *endpoint = user_data;
     AWS_PRECONDITION(endpoint);
@@ -240,7 +221,7 @@ static void s_s3_endpoint_ref_count_zero(void *user_data) {
         endpoint->http_connection_manager = NULL;
         aws_http_connection_manager_release(http_connection_manager);
     } else {
-        s_s3_endpoint_http_connection_manager_shutdown_callback(endpoint->user_data);
+        s_s3_endpoint_http_connection_manager_shutdown_callback(endpoint);
     }
 }
 
@@ -249,12 +230,13 @@ static void s_s3_endpoint_http_connection_manager_shutdown_callback(void *user_d
     AWS_ASSERT(endpoint);
 
     aws_s3_endpoint_shutdown_fn *shutdown_callback = endpoint->shutdown_callback;
+    struct aws_string *endpoint_host_name = endpoint->host_name;
     void *endpoint_user_data = endpoint->user_data;
 
     aws_mem_release(endpoint->allocator, endpoint);
 
     if (shutdown_callback != NULL) {
-        shutdown_callback(endpoint_user_data);
+        shutdown_callback(endpoint_host_name, endpoint_user_data);
     }
 }
 

--- a/source/s3_endpoint.c
+++ b/source/s3_endpoint.c
@@ -224,11 +224,11 @@ void aws_s3_client_endpoint_release(struct aws_s3_client *client, struct aws_s3_
         if (aws_atomic_load_int(&endpoint->ref_count.ref_count) == 1) {
             aws_hash_table_remove(&client->synced_data.endpoints, endpoint->host_name, NULL, NULL);
         }
+        aws_ref_count_release(&endpoint->ref_count);
+
         aws_s3_client_unlock_synced_data(client);
     }
     /* END CRITICAL SECTION */
-
-    aws_ref_count_release(&endpoint->ref_count);
 }
 
 static void s_s3_endpoint_ref_count_zero(void *user_data) {

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -1444,8 +1444,7 @@ void aws_s3_meta_request_finish_default(struct aws_s3_meta_request *meta_request
 
     aws_s3_meta_request_result_clean_up(meta_request, &finish_result);
 
-    /* The endpoint must be created by client here */
-    aws_s3_client_endpoint_release(meta_request->client, meta_request->endpoint);
+    aws_s3_endpoint_release(meta_request->endpoint);
     meta_request->endpoint = NULL;
 
     aws_s3_client_release(meta_request->client);


### PR DESCRIPTION
This fixes the race condition in `aws_s3_client_endpoint_release` reported in #202.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
