### PR TITLE
don't cover the error code with retry failure

### DIFF
--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -1592,7 +1592,6 @@ void aws_s3_client_notify_connection_finished(
         /* Ask the retry strategy to schedule a retry of the request. */
         if (aws_retry_strategy_schedule_retry(
                 connection->retry_token, error_type, s_s3_client_retry_ready, connection)) {
-            error_code = aws_last_error_or_unknown();
 
             AWS_LOGF_ERROR(
                 AWS_LS_S3_CLIENT,
@@ -1601,8 +1600,8 @@ void aws_s3_client_notify_connection_finished(
                 (void *)request,
                 (void *)meta_request,
                 (void *)connection->retry_token,
-                error_code,
-                aws_error_str(error_code));
+                aws_last_error_or_unknown(),
+                aws_error_str(aws_last_error_or_unknown()));
 
             goto reset_connection;
         }

--- a/tests/s3_retry_tests.c
+++ b/tests/s3_retry_tests.c
@@ -26,8 +26,8 @@ static void s_s3_client_acquire_http_connection_exceed_retries(
     AWS_ASSERT(callback);
     (void)conn_manager;
 
-    aws_raise_error(AWS_ERROR_UNKNOWN);
-    callback(NULL, AWS_ERROR_UNKNOWN, user_data);
+    aws_raise_error(AWS_ERROR_HTTP_UNKNOWN);
+    callback(NULL, AWS_ERROR_HTTP_UNKNOWN, user_data);
 }
 
 AWS_TEST_CASE(test_s3_client_exceed_retries, s_test_s3_client_exceed_retries)
@@ -56,7 +56,7 @@ static int s_test_s3_client_exceed_retries(struct aws_allocator *allocator, void
     ASSERT_SUCCESS(aws_s3_tester_send_get_object_meta_request(
         &tester, client, g_s3_path_get_object_test_1MB, 0, &meta_request_test_results));
 
-    ASSERT_TRUE(meta_request_test_results.finished_error_code == AWS_IO_MAX_RETRIES_EXCEEDED);
+    ASSERT_TRUE(meta_request_test_results.finished_error_code == AWS_ERROR_HTTP_UNKNOWN);
 
     aws_s3_meta_request_test_results_clean_up(&meta_request_test_results);
 


### PR DESCRIPTION
- In the case of retry failed, we report the error from retry, which is not informative to the end user.
- Instead, we should report the error that causing the retry. And just log the retry failure if more details needed.
- Related https://github.com/aws/aws-sdk-java-v2/issues/3372


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
