### PR TITLE
Endpoint lifetime fix

### DIFF
--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -78,7 +78,13 @@ struct aws_s3_endpoint {
 
     /* If the endpoint registered to the hashtable owned by client, set the pointer to client for unregister from the
      * hashtable once endpoint started to clean itself up.  */
-    struct aws_s3_client *client;
+    struct {
+        /* Protected by the client lock */
+        struct aws_s3_client *client;
+        struct aws_task *task;
+        bool task_scheduled;
+        size_t num_released;
+    } async_release;
 
     void *user_data;
 };

--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -318,7 +318,7 @@ AWS_S3_API
 void aws_s3_client_unlock_synced_data(struct aws_s3_client *client);
 
 AWS_S3_API
-struct aws_s3_endpoint *aws_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint);
+struct aws_s3_endpoint *aws_s3_endpoint_acquire_synced(struct aws_s3_endpoint *endpoint);
 
 AWS_S3_API
 void aws_s3_endpoint_release(struct aws_s3_endpoint *endpoint);

--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -76,9 +76,9 @@ struct aws_s3_endpoint {
     /* Callback for when this endpoint completely shuts down. */
     aws_s3_endpoint_shutdown_fn *shutdown_callback;
 
-    /* True, if the endpoint is created by client. So, it need to be thread safe to manage the refcount via
-     * `aws_s3_client_endpoint_release` */
-    bool handled_by_client;
+    /* If the endpoint registered to the hashtable owned by client, set the pointer to client for unregister from the
+     * hashtable once endpoint started to clean itself up.  */
+    struct aws_s3_client *client;
 
     void *user_data;
 };
@@ -313,11 +313,6 @@ struct aws_s3_endpoint *aws_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint
 
 AWS_S3_API
 void aws_s3_endpoint_release(struct aws_s3_endpoint *endpoint);
-
-/* If the endpoint is created by s3 client, it will be managed by the client via a hash table that need to be protected
- * by lock. A lock will be acquired within the call, never invoke with lock held */
-AWS_S3_API
-void aws_s3_client_endpoint_release(struct aws_s3_client *client, struct aws_s3_endpoint *endpoint);
 
 AWS_S3_API
 extern const uint32_t g_max_num_connections_per_vip;

--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -76,13 +76,16 @@ struct aws_s3_endpoint {
     /* Callback for when this endpoint completely shuts down. */
     aws_s3_endpoint_shutdown_fn *shutdown_callback;
 
-    /* If the endpoint registered to the hashtable owned by client, set the pointer to client for unregister from the
-     * hashtable once endpoint started to clean itself up.  */
+    /* For S3 client to handle the hashtable of endpoints. */
     struct {
-        /* Protected by the client lock */
+        /* Point to the client. */
         struct aws_s3_client *client;
+        /* If set, the release of endpoint will be scheduled to run within the task to prevent the data race with client
+         */
         struct aws_task *task;
+        /* The task has been scheduled or not. */
         bool task_scheduled;
+        /* Number of release called before the task runs */
         size_t num_released;
     } async_release;
 

--- a/source/s3_endpoint.c
+++ b/source/s3_endpoint.c
@@ -196,7 +196,7 @@ static struct aws_http_connection_manager *s_s3_endpoint_create_http_connection_
     return http_connection_manager;
 }
 
-struct aws_s3_endpoint *aws_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint) {
+struct aws_s3_endpoint *aws_s3_endpoint_acquire_synced(struct aws_s3_endpoint *endpoint) {
     AWS_PRECONDITION(endpoint);
 
     aws_ref_count_acquire(&endpoint->ref_count);

--- a/source/s3_endpoint.c
+++ b/source/s3_endpoint.c
@@ -223,9 +223,9 @@ void aws_s3_endpoint_release(struct aws_s3_endpoint *endpoint) {
         }
         /* END CRITICAL SECTION */
         if (schedule_task) {
+            aws_s3_client_acquire(endpoint->async_release.client);
             aws_event_loop_schedule_task_now(
                 endpoint->async_release.client->process_work_event_loop, endpoint->async_release.task);
-            aws_s3_client_acquire(endpoint->async_release.client);
         }
     } else {
         aws_ref_count_release(&endpoint->ref_count);

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -385,6 +385,7 @@ static void s_s3_meta_request_destroy(void *user_data) {
     aws_mutex_clean_up(&meta_request->synced_data.lock);
 
     aws_s3_endpoint_release(meta_request->endpoint);
+    meta_request->endpoint = NULL;
     aws_s3_client_release(meta_request->client);
 
     AWS_ASSERT(aws_priority_queue_size(&meta_request->synced_data.pending_body_streaming_requests) == 0);

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -383,8 +383,7 @@ static void s_s3_meta_request_destroy(void *user_data) {
 
     aws_cached_signing_config_destroy(meta_request->cached_signing_config);
     aws_mutex_clean_up(&meta_request->synced_data.lock);
-    /* For a meta request created by client, the endpoint should always be cleaned up by meta request finish call. Just
-     * use regular release here for those meta request not really went through the client */
+
     aws_s3_endpoint_release(meta_request->endpoint);
     aws_s3_client_release(meta_request->client);
 
@@ -1444,8 +1443,7 @@ void aws_s3_meta_request_finish_default(struct aws_s3_meta_request *meta_request
 
     aws_s3_meta_request_result_clean_up(meta_request, &finish_result);
 
-    /* The endpoint must be created by client here */
-    aws_s3_client_endpoint_release(meta_request->client, meta_request->endpoint);
+    aws_s3_endpoint_release(meta_request->endpoint);
     meta_request->endpoint = NULL;
 
     aws_s3_client_release(meta_request->client);


### PR DESCRIPTION
*Issue #, if available:*

- The release of the endpoint will lead to touch the hashtable owned by client, which needs to be protected by lock.
- We have the issue that when the refcount of endpoint drops to zero, we need to grab the lock and remove the endpoint from hashtable. But there is a race between client grab the lock to find the endpoint from hashtable and release of endpoint to remove itself from hashtable.
- Related issue https://github.com/awslabs/aws-c-s3/issues/202

*Description of changes:*

- We cannot always make sure the lock be grab to release the refcount. So that, we schedule a task to always be safe to grab lock and check the refcount and decide to remove it from hashtable or not

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
