### PR TITLE
Fix race condition with aws_s3_endpoint acquire/release

### DIFF
--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -98,7 +98,7 @@ struct aws_s3_endpoint_options {
 
 /* global vtable, only used when mocking for tests */
 struct aws_s3_endpoint_system_vtable {
-    void (*acquire)(struct aws_s3_endpoint *endpoint);
+    void (*acquire)(struct aws_s3_endpoint *endpoint, bool already_holding_lock);
     void (*release)(struct aws_s3_endpoint *endpoint);
 };
 
@@ -390,9 +390,8 @@ AWS_S3_API
 void aws_s3_endpoint_set_system_vtable(const struct aws_s3_endpoint_system_vtable *vtable);
 
 /* Increment the endpoint's ref-count.
- * You MUST NOT call this while the client's lock is held.
- * (this call briefly holds the client's lock) */
-struct aws_s3_endpoint *aws_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint);
+ * If `already_holding_lock` is false, then this call will briefly take hold of the client's lock */
+struct aws_s3_endpoint *aws_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint, bool already_holding_lock);
 
 /* Decrement the endpoint's ref-count.
  * You MUST NOT call this while the client's lock is held.

--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -105,7 +105,7 @@ struct aws_s3_endpoint_system_vtable {
 struct aws_s3_endpoint {
     struct {
         /* This is NOT an atomic ref-count.
-         * The endpoint lives in hashtable: `aws_s3_client.threaded_data.endpoints`
+         * The endpoint lives in hashtable: `aws_s3_client.synced_data.endpoints`
          * This ref-count can only be touched while holding client's lock */
         size_t ref_count;
     } client_synced_data;

--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -52,8 +52,8 @@ struct aws_s3_endpoint_options {
     /* DNS TTL to use for addresses for this endpoint. */
     size_t dns_host_address_ttl_seconds;
 
-    /* User data to be passed around with the endpoint. */
-    void *user_data;
+    /* Client that owns this endpoint */
+    struct aws_s3_client *client;
 
     /* Maximum number of connections that can be spawned for this endpoint. */
     uint32_t max_connections;
@@ -96,9 +96,19 @@ struct aws_s3_endpoint_options {
     struct aws_http_connection_monitoring_options *monitoring_options;
 };
 
+/* global vtable, only used when mocking for tests */
+struct aws_s3_endpoint_system_vtable {
+    void (*acquire)(struct aws_s3_endpoint *endpoint);
+    void (*release)(struct aws_s3_endpoint *endpoint);
+};
+
 struct aws_s3_endpoint {
-    /* Reference count for this endpoint. */
-    struct aws_ref_count ref_count;
+    struct {
+        /* This is NOT an atomic ref-count.
+         * The endpoint lives in hashtable: `aws_s3_client.threaded_data.endpoints`
+         * This ref-count can only be touched while holding client's lock */
+        size_t ref_count;
+    } client_synced_data;
 
     /* What allocator was used to create this endpoint. */
     struct aws_allocator *allocator;
@@ -109,14 +119,8 @@ struct aws_s3_endpoint {
     /* Connection manager that manages all connections to this endpoint. */
     struct aws_http_connection_manager *http_connection_manager;
 
-    /* Callback for when this endpoint completely shuts down. */
-    aws_s3_endpoint_shutdown_fn *shutdown_callback;
-
-    /* True, if the endpoint is created by client. So, it need to be thread safe to manage the refcount via
-     * `aws_s3_client_endpoint_release` */
-    bool handled_by_client;
-
-    void *user_data;
+    /* Client that owns this endpoint */
+    struct aws_s3_client *client;
 };
 
 /* Represents one connection on a particular VIP. */
@@ -155,7 +159,7 @@ struct aws_s3_client_vtable {
 
     void (*process_work)(struct aws_s3_client *client);
 
-    void (*endpoint_shutdown_callback)(void *user_data);
+    void (*endpoint_shutdown_callback)(struct aws_s3_client *client);
 
     void (*finish_destroy)(struct aws_s3_client *client);
 };
@@ -381,16 +385,20 @@ AWS_S3_API void aws_s3_client_lock_synced_data(struct aws_s3_client *client);
 AWS_S3_API
 void aws_s3_client_unlock_synced_data(struct aws_s3_client *client);
 
+/* Used for mocking */
 AWS_S3_API
+void aws_s3_endpoint_set_system_vtable(const struct aws_s3_endpoint_system_vtable *vtable);
+
+/* Increment the endpoint's ref-count.
+ * You MUST NOT call this while the client's lock is held.
+ * (this call briefly holds the client's lock) */
 struct aws_s3_endpoint *aws_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint);
 
-AWS_S3_API
+/* Decrement the endpoint's ref-count.
+ * You MUST NOT call this while the client's lock is held.
+ * (this call briefly holds the client's lock and may remove the endpoint
+ * from the client's hashtable) */
 void aws_s3_endpoint_release(struct aws_s3_endpoint *endpoint);
-
-/* If the endpoint is created by s3 client, it will be managed by the client via a hash table that need to be protected
- * by lock. A lock will be acquired within the call, never invoke with lock held */
-AWS_S3_API
-void aws_s3_client_endpoint_release(struct aws_s3_client *client, struct aws_s3_endpoint *endpoint);
 
 AWS_S3_API
 extern const uint32_t g_max_num_connections_per_vip;

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -756,9 +756,7 @@ struct aws_s3_meta_request *aws_s3_client_make_meta_request(
         } else {
             endpoint = endpoint_hash_element->value;
 
-            /* not calling aws_s3_endpoint_acquire() because that would grab the client lock */
-            AWS_ASSERT(endpoint->client_synced_data.ref_count > 0);
-            ++endpoint->client_synced_data.ref_count;
+            aws_s3_endpoint_acquire(endpoint, true /*already_holding_lock*/);
 
             aws_string_destroy(endpoint_host_name);
             endpoint_host_name = NULL;
@@ -1429,7 +1427,7 @@ static void s_s3_client_create_connection_for_request_default(
 
     struct aws_s3_connection *connection = aws_mem_calloc(client->allocator, 1, sizeof(struct aws_s3_connection));
 
-    connection->endpoint = aws_s3_endpoint_acquire(meta_request->endpoint);
+    connection->endpoint = aws_s3_endpoint_acquire(meta_request->endpoint, false /*already_holding_lock*/);
     connection->request = request;
 
     struct aws_byte_cursor host_header_value;

--- a/source/s3_endpoint.c
+++ b/source/s3_endpoint.c
@@ -59,7 +59,22 @@ static struct aws_http_connection_manager *s_s3_endpoint_create_http_connection_
 
 static void s_s3_endpoint_http_connection_manager_shutdown_callback(void *user_data);
 
-static void s_s3_endpoint_ref_count_zero(void *user_data);
+static void s_s3_endpoint_ref_count_zero(struct aws_s3_endpoint *endpoint);
+
+static void s_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint);
+
+static void s_s3_endpoint_release(struct aws_s3_endpoint *endpoint);
+
+static const struct aws_s3_endpoint_system_vtable s_s3_endpoint_default_system_vtable = {
+    .acquire = s_s3_endpoint_acquire,
+    .release = s_s3_endpoint_release,
+};
+
+static const struct aws_s3_endpoint_system_vtable *s_s3_endpoint_system_vtable = &s_s3_endpoint_default_system_vtable;
+
+void aws_s3_endpoint_set_system_vtable(const struct aws_s3_endpoint_system_vtable *vtable) {
+    s_s3_endpoint_system_vtable = vtable;
+}
 
 struct aws_s3_endpoint *aws_s3_endpoint_new(
     struct aws_allocator *allocator,
@@ -69,7 +84,7 @@ struct aws_s3_endpoint *aws_s3_endpoint_new(
     AWS_PRECONDITION(options->host_name);
 
     struct aws_s3_endpoint *endpoint = aws_mem_calloc(allocator, 1, sizeof(struct aws_s3_endpoint));
-    aws_ref_count_init(&endpoint->ref_count, endpoint, s_s3_endpoint_ref_count_zero);
+    endpoint->client_synced_data.ref_count = 1;
 
     endpoint->allocator = allocator;
     endpoint->host_name = options->host_name;
@@ -113,8 +128,7 @@ struct aws_s3_endpoint *aws_s3_endpoint_new(
         goto error_cleanup;
     }
 
-    endpoint->shutdown_callback = options->shutdown_callback;
-    endpoint->user_data = options->user_data;
+    endpoint->client = options->client;
 
     return endpoint;
 
@@ -159,7 +173,7 @@ static struct aws_http_connection_manager *s_s3_endpoint_create_http_connection_
         socket_options.keep_alive_max_failed_probes = tcp_keep_alive_options->keep_alive_max_failed_probes;
     }
     struct proxy_env_var_settings proxy_ev_settings_default;
-    /* Turn on envrionment variable for proxy by default */
+    /* Turn on environment variable for proxy by default */
     if (proxy_ev_settings == NULL) {
         AWS_ZERO_STRUCT(proxy_ev_settings_default);
         proxy_ev_settings_default.env_var_type = AWS_HPEV_ENABLE;
@@ -230,65 +244,72 @@ static struct aws_http_connection_manager *s_s3_endpoint_create_http_connection_
 }
 
 struct aws_s3_endpoint *aws_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint) {
-    AWS_PRECONDITION(endpoint);
-
-    aws_ref_count_acquire(&endpoint->ref_count);
-
+    if (endpoint) {
+        s_s3_endpoint_system_vtable->acquire(endpoint);
+    }
     return endpoint;
 }
 
-void aws_s3_endpoint_release(struct aws_s3_endpoint *endpoint) {
-    if (endpoint == NULL) {
-        return;
-    }
+static void s_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint) {
+    AWS_PRECONDITION(endpoint);
 
-    aws_ref_count_release(&endpoint->ref_count);
+    aws_s3_client_lock_synced_data(endpoint->client);
+    AWS_ASSERT(endpoint->client_synced_data.ref_count > 0);
+    ++endpoint->client_synced_data.ref_count;
+    aws_s3_client_unlock_synced_data(endpoint->client);
 }
 
-void aws_s3_client_endpoint_release(struct aws_s3_client *client, struct aws_s3_endpoint *endpoint) {
+void aws_s3_endpoint_release(struct aws_s3_endpoint *endpoint) {
+    if (endpoint) {
+        s_s3_endpoint_system_vtable->release(endpoint);
+    }
+}
+
+static void s_s3_endpoint_release(struct aws_s3_endpoint *endpoint) {
     AWS_PRECONDITION(endpoint);
-    AWS_PRECONDITION(client);
-    AWS_PRECONDITION(endpoint->handled_by_client);
+    AWS_PRECONDITION(endpoint->client);
 
     /* BEGIN CRITICAL SECTION */
-    {
-        aws_s3_client_lock_synced_data(client);
-        /* The last refcount to release */
-        if (aws_atomic_load_int(&endpoint->ref_count.ref_count) == 1) {
-            aws_hash_table_remove(&client->synced_data.endpoints, endpoint->host_name, NULL, NULL);
-        }
-        aws_s3_client_unlock_synced_data(client);
+    aws_s3_client_lock_synced_data(endpoint->client);
+
+    AWS_ASSERT(endpoint->client_synced_data.ref_count > 0);
+    bool refcount_is_zero = (--endpoint->client_synced_data.ref_count == 0);
+    if (refcount_is_zero) {
+        aws_hash_table_remove(&endpoint->client->synced_data.endpoints, endpoint->host_name, NULL, NULL);
     }
+
+    aws_s3_client_unlock_synced_data(endpoint->client);
     /* END CRITICAL SECTION */
 
-    aws_ref_count_release(&endpoint->ref_count);
+    if (refcount_is_zero) {
+        /* The endpoint may have async cleanup to do (connection manager).
+         * When that's all done we'll invoke a completion callback.
+         * Since it's a crime to hold a lock while invoking a callback,
+         * we make sure that we've released the client's lock before proceeding... */
+        s_s3_endpoint_ref_count_zero(endpoint);
+    }
 }
 
-static void s_s3_endpoint_ref_count_zero(void *user_data) {
-    struct aws_s3_endpoint *endpoint = user_data;
+static void s_s3_endpoint_ref_count_zero(struct aws_s3_endpoint *endpoint) {
     AWS_PRECONDITION(endpoint);
+    AWS_PRECONDITION(endpoint->http_connection_manager);
 
-    if (endpoint->http_connection_manager != NULL) {
-        struct aws_http_connection_manager *http_connection_manager = endpoint->http_connection_manager;
-        endpoint->http_connection_manager = NULL;
-        aws_http_connection_manager_release(http_connection_manager);
-    } else {
-        s_s3_endpoint_http_connection_manager_shutdown_callback(endpoint->user_data);
-    }
+    struct aws_http_connection_manager *http_connection_manager = endpoint->http_connection_manager;
+    endpoint->http_connection_manager = NULL;
+
+    /* Cleanup continues once the manager's shutdown callback is invoked */
+    aws_http_connection_manager_release(http_connection_manager);
 }
 
 static void s_s3_endpoint_http_connection_manager_shutdown_callback(void *user_data) {
     struct aws_s3_endpoint *endpoint = user_data;
     AWS_ASSERT(endpoint);
 
-    aws_s3_endpoint_shutdown_fn *shutdown_callback = endpoint->shutdown_callback;
-    void *endpoint_user_data = endpoint->user_data;
+    struct aws_s3_client *client = endpoint->client;
 
     aws_mem_release(endpoint->allocator, endpoint);
 
-    if (shutdown_callback != NULL) {
-        shutdown_callback(endpoint_user_data);
-    }
+    client->vtable->endpoint_shutdown_callback(client);
 }
 
 static void s_s3_endpoint_on_host_resolver_address_resolved(
@@ -302,4 +323,5 @@ static void s_s3_endpoint_on_host_resolver_address_resolved(
     (void)err_code;
     (void)host_addresses;
     (void)user_data;
+    /* DO NOT add any logic here, unless you also ensure the endpoint lives long enough */
 }

--- a/source/s3_endpoint.c
+++ b/source/s3_endpoint.c
@@ -61,7 +61,7 @@ static void s_s3_endpoint_http_connection_manager_shutdown_callback(void *user_d
 
 static void s_s3_endpoint_ref_count_zero(struct aws_s3_endpoint *endpoint);
 
-static void s_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint);
+static void s_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint, bool already_holding_lock);
 
 static void s_s3_endpoint_release(struct aws_s3_endpoint *endpoint);
 
@@ -243,20 +243,26 @@ static struct aws_http_connection_manager *s_s3_endpoint_create_http_connection_
     return http_connection_manager;
 }
 
-struct aws_s3_endpoint *aws_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint) {
+struct aws_s3_endpoint *aws_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint, bool already_holding_lock) {
     if (endpoint) {
-        s_s3_endpoint_system_vtable->acquire(endpoint);
+        s_s3_endpoint_system_vtable->acquire(endpoint, already_holding_lock);
     }
     return endpoint;
 }
 
-static void s_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint) {
+static void s_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint, bool already_holding_lock) {
     AWS_PRECONDITION(endpoint);
 
-    aws_s3_client_lock_synced_data(endpoint->client);
+    if (!already_holding_lock) {
+        aws_s3_client_lock_synced_data(endpoint->client);
+    }
+
     AWS_ASSERT(endpoint->client_synced_data.ref_count > 0);
     ++endpoint->client_synced_data.ref_count;
-    aws_s3_client_unlock_synced_data(endpoint->client);
+
+    if (!already_holding_lock) {
+        aws_s3_client_unlock_synced_data(endpoint->client);
+    }
 }
 
 void aws_s3_endpoint_release(struct aws_s3_endpoint *endpoint) {
@@ -272,16 +278,17 @@ static void s_s3_endpoint_release(struct aws_s3_endpoint *endpoint) {
     /* BEGIN CRITICAL SECTION */
     aws_s3_client_lock_synced_data(endpoint->client);
 
-    AWS_ASSERT(endpoint->client_synced_data.ref_count > 0);
-    bool refcount_is_zero = (--endpoint->client_synced_data.ref_count == 0);
-    if (refcount_is_zero) {
+    bool should_destroy = (endpoint->client_synced_data.ref_count == 1);
+    if (should_destroy) {
         aws_hash_table_remove(&endpoint->client->synced_data.endpoints, endpoint->host_name, NULL, NULL);
+    } else {
+        --endpoint->client_synced_data.ref_count;
     }
 
     aws_s3_client_unlock_synced_data(endpoint->client);
     /* END CRITICAL SECTION */
 
-    if (refcount_is_zero) {
+    if (should_destroy) {
         /* The endpoint may have async cleanup to do (connection manager).
          * When that's all done we'll invoke a completion callback.
          * Since it's a crime to hold a lock while invoking a callback,

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -383,8 +383,8 @@ static void s_s3_meta_request_destroy(void *user_data) {
 
     aws_cached_signing_config_destroy(meta_request->cached_signing_config);
     aws_mutex_clean_up(&meta_request->synced_data.lock);
-    /* For a meta request created by client, the endpoint should always be cleaned up by meta request finish call. Just
-     * use regular release here for those meta request not really went through the client */
+    /* endpoint and client should have already been released and set NULL by the meta request finish call.
+     * But call release() again, just in case we're tearing down a half-initialized meta request */
     aws_s3_endpoint_release(meta_request->endpoint);
     aws_s3_client_release(meta_request->client);
 
@@ -1444,8 +1444,7 @@ void aws_s3_meta_request_finish_default(struct aws_s3_meta_request *meta_request
 
     aws_s3_meta_request_result_clean_up(meta_request, &finish_result);
 
-    /* The endpoint must be created by client here */
-    aws_s3_client_endpoint_release(meta_request->client, meta_request->endpoint);
+    aws_s3_endpoint_release(meta_request->endpoint);
     meta_request->endpoint = NULL;
 
     aws_s3_client_release(meta_request->client);

--- a/tests/s3_retry_tests.c
+++ b/tests/s3_retry_tests.c
@@ -74,7 +74,7 @@ static void s_s3_client_acquire_http_connection_fail_first(
 
     struct aws_s3_connection *connection = user_data;
 
-    struct aws_s3_client *client = connection->request->meta_request->endpoint->user_data;
+    struct aws_s3_client *client = connection->request->meta_request->endpoint->client;
     AWS_ASSERT(client);
 
     struct aws_s3_tester *tester = client->shutdown_callback_user_data;

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -742,7 +742,8 @@ struct aws_s3_empty_meta_request {
     struct aws_s3_meta_request base;
 };
 
-static void s_s3_mock_endpoint_acquire(struct aws_s3_endpoint *endpoint) {
+static void s_s3_mock_endpoint_acquire(struct aws_s3_endpoint *endpoint, bool already_holding_lock) {
+    (void)already_holding_lock;
     ++endpoint->client_synced_data.ref_count;
 }
 

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -589,9 +589,9 @@ static void s_s3_client_process_work_empty(struct aws_s3_client *client) {
     (void)client;
 }
 
-static void s_s3_client_endpoint_shutdown_callback_empty(void *user_data) {
-    AWS_PRECONDITION(user_data);
-    (void)user_data;
+static void s_s3_client_endpoint_shutdown_callback_empty(struct aws_s3_client *client) {
+    AWS_PRECONDITION(client);
+    (void)client;
 }
 
 static void s_s3_client_finish_destroy_empty(struct aws_s3_client *client) {
@@ -742,17 +742,28 @@ struct aws_s3_empty_meta_request {
     struct aws_s3_meta_request base;
 };
 
-static void s_s3_mock_endpoint_zero_ref(void *user_data) {
-    struct aws_s3_endpoint *endpoint = user_data;
-
-    aws_string_destroy(endpoint->host_name);
-    aws_mem_release(endpoint->allocator, endpoint);
+static void s_s3_mock_endpoint_acquire(struct aws_s3_endpoint *endpoint) {
+    ++endpoint->client_synced_data.ref_count;
 }
 
+static void s_s3_mock_endpoint_release(struct aws_s3_endpoint *endpoint) {
+    if (--endpoint->client_synced_data.ref_count == 0) {
+        aws_string_destroy(endpoint->host_name);
+        aws_mem_release(endpoint->allocator, endpoint);
+    }
+}
+
+static struct aws_s3_endpoint_system_vtable s_s3_mock_endpoint_vtable = {
+    .acquire = s_s3_mock_endpoint_acquire,
+    .release = s_s3_mock_endpoint_release,
+};
+
 struct aws_s3_endpoint *aws_s3_tester_mock_endpoint_new(struct aws_s3_tester *tester) {
+    aws_s3_endpoint_set_system_vtable(&s_s3_mock_endpoint_vtable);
+
     struct aws_s3_endpoint *endpoint = aws_mem_calloc(tester->allocator, 1, sizeof(struct aws_s3_endpoint));
     endpoint->allocator = tester->allocator;
-    aws_ref_count_init(&endpoint->ref_count, endpoint, s_s3_mock_endpoint_zero_ref);
+    endpoint->client_synced_data.ref_count = 1;
 
     struct aws_byte_cursor empty_cursor = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("");
     endpoint->host_name = aws_string_new_from_cursor(tester->allocator, &empty_cursor);


### PR DESCRIPTION
**Issue:**
https://github.com/awslabs/aws-c-s3/issues/202

There are race conditions around the removal of endpoints from the client's hashtable

**Description of changes:**
1) Always hold the client's lock while acquiring and releasing an endpoint's refcount.
    - The old bugs were due to an unholy mix of atomic operations and locks. But when you have two related bits of data touched from multiple threads (the endpoint, and the hashtable it's stored in) atomics don't cut it anymore. You must always be holding the lock when touching either bit of data.
2) Add a vtable for `aws_s3_endpoint`
    - This lets us separate the "real" implementation from the "mocked testing" implementation. The existing code had a lot of "if owned by client" (aka "real world") branches and made the lifetime/ownership hard to follow. Now the "real" implementation is only the "real" implementation.

**Rambling:**
This isn't our first time trying to fix these race conditions. See:
- https://github.com/awslabs/aws-c-s3/pull/183
- https://github.com/awslabs/aws-c-s3/pull/208

We also considered moving the endpoint hashtable out of `synced_data` and onto `thread_data`, and changing `aws_s3_acquire()/release()` calls so they become scheduled tasks under the hood. But this would have been a significant refactor. Once I'd spent 2 days staring at this code I understood it well enough to (hopefully) fix it with a small change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
