### PR TITLE
Alternative "make request" function to avoid race conditions

### DIFF
--- a/include/aws/s3/private/s3_meta_request_impl.h
+++ b/include/aws/s3/private/s3_meta_request_impl.h
@@ -126,6 +126,7 @@ struct aws_s3_meta_request {
     void *user_data;
 
     /* Customer specified callbacks. */
+    aws_s3_meta_request_init_callback_fn *init_callback;
     aws_s3_meta_request_headers_callback_fn *headers_callback;
     aws_s3_meta_request_receive_body_callback_fn *body_callback;
     aws_s3_meta_request_finish_fn *finish_callback;
@@ -183,9 +184,6 @@ struct aws_s3_meta_request {
         /* Linked list node for the meta requests linked list in the client. */
         /* Note: this needs to be first for using AWS_CONTAINER_OF with the nested structure. */
         struct aws_linked_list_node node;
-
-        /* True if this meta request is currently in the client's list. */
-        bool scheduled;
 
     } client_process_work_threaded_data;
 

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -67,22 +67,17 @@ enum aws_s3_meta_request_type {
  * This is the first callback invoked after a successful call to aws_s3_client_start_meta_request().
  * This callback is always invoked asynchronously.
  *
- * If error_code is zero, the meta_request was created successfully.
- * meta_request is a valid pointer that you now own. You must eventually
- * call aws_s3_meta_request_release() when you are completely done with the
- * pointer, so that it can be cleaned up. Even if return AWS_OP_ERR from this
- * function to cancel the meta request, you still own this pointer and must
- * release it properly to prevent memory leaks.
- *
- * If error_code is non-zero, the meta request failed to be created.
- * meta_request is NULL and no further callbacks will fire.
+ * meta_request is a valid pointer that you now own.
+ * You must eventually call aws_s3_meta_request_release() when you are
+ * completely done with the pointer, so that it can be cleaned up.
+ * Even if you return AWS_OP_ERR from this function to cancel the meta
+ * request, you still own this pointer and must release it properly to
+ * prevent memory leaks. This pointer is never NULL.
  *
  * Return AWS_OP_SUCCESS to continue processing the request.
  * Return AWS_OP_ERR to indicate failure and cancel the request.
  */
-typedef int (aws_s3_meta_request_init_callback_fn)(
-    struct aws_s3_meta_request *meta_request,
-    int error_code);
+typedef int(aws_s3_meta_request_init_callback_fn)(struct aws_s3_meta_request *meta_request, void *user_data);
 
 /**
  * Invoked to provide response headers received during execution of the meta request, both for
@@ -384,7 +379,7 @@ struct aws_s3_meta_request_options {
      * This callback is always invoked asynchronously.
      * See `aws_s3_meta_request_init_callback_fn`.
      */
-     aws_s3_meta_request_init_callback_fn *init_callback;
+    aws_s3_meta_request_init_callback_fn *init_callback;
 
     /**
      * Optional.
@@ -502,9 +497,7 @@ void aws_s3_client_release(struct aws_s3_client *client);
  * If unsuccessful, AWS_OP_ERR is returned and no callbacks will be invoked.
  */
 AWS_S3_API
-int aws_s3_client_start_meta_request(
-        struct aws_s3_client *client,
-        const struct aws_s3_meta_request_options *options);
+int aws_s3_client_start_meta_request(struct aws_s3_client *client, const struct aws_s3_meta_request_options *options);
 
 /**
  * @Deprecated - Use aws_s3_client_start_meta_request() instead.

--- a/source/s3.c
+++ b/source/s3.c
@@ -41,7 +41,7 @@ static struct aws_error_info s_errors[] = {
 
 static struct aws_error_info_list s_error_list = {
     .error_list = s_errors,
-    .count = sizeof(s_errors) / sizeof(struct aws_error_info),
+    .count = AWS_ARRAY_SIZE(s_errors),
 };
 
 static struct aws_log_subject_info s_s3_log_subject_infos[] = {

--- a/source/s3_auto_ranged_put.c
+++ b/source/s3_auto_ranged_put.c
@@ -206,7 +206,7 @@ static int s_load_persistable_state(
     auto_ranged_put->synced_data.list_parts_operation = aws_s3_list_parts_operation_new(allocator, &list_parts_params);
 
     struct aws_http_headers *needed_response_headers = aws_http_headers_new(allocator);
-    const size_t copy_header_count = sizeof(s_create_multipart_upload_copy_headers) / sizeof(struct aws_byte_cursor);
+    const size_t copy_header_count = AWS_ARRAY_SIZE(s_create_multipart_upload_copy_headers);
     struct aws_http_headers *initial_headers =
         aws_http_message_get_headers(auto_ranged_put->base.initial_request_message);
 
@@ -971,8 +971,7 @@ static void s_s3_auto_ranged_put_request_finished(
 
             if (error_code == AWS_ERROR_SUCCESS) {
                 needed_response_headers = aws_http_headers_new(meta_request->allocator);
-                const size_t copy_header_count =
-                    sizeof(s_create_multipart_upload_copy_headers) / sizeof(struct aws_byte_cursor);
+                const size_t copy_header_count = AWS_ARRAY_SIZE(s_create_multipart_upload_copy_headers);
 
                 /* Copy any headers now that we'll need for the final, transformed headers later. */
                 for (size_t header_index = 0; header_index < copy_header_count; ++header_index) {

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -832,8 +832,6 @@ static struct aws_s3_meta_request *s_s3_client_create_meta_request(
 
         aws_s3_meta_request_release(meta_request);
         meta_request = NULL;
-    } else {
-        AWS_LOGF_INFO(AWS_LS_S3_CLIENT, "id=%p: Created meta request %p", (void *)client, (void *)meta_request);
     }
 
     return meta_request;
@@ -846,7 +844,7 @@ int aws_s3_client_start_meta_request(struct aws_s3_client *client, const struct 
 
     if (options->init_callback == NULL) {
         AWS_LOGF_ERROR(
-            AWS_LS_S3_CLIENT, "id=%p Cannot create meta s3 request; init callback must be set", (void *)client);
+            AWS_LS_S3_CLIENT, "id=%p Cannot create meta s3 request; init callback must be set.", (void *)client);
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
@@ -872,14 +870,14 @@ struct aws_s3_meta_request *aws_s3_client_make_meta_request(
 
     AWS_LOGF_WARN(
         AWS_LS_S3_CLIENT,
-        "id=%p Using deprecated function 'make_meta_request()', use 'start_meta_request()' instead",
+        "id=%p Using deprecated function 'make_meta_request()', use 'start_meta_request()' instead.",
         (void *)client);
 
     if (options->init_callback != NULL) {
         AWS_LOGF_ERROR(
             AWS_LS_S3_CLIENT,
             "id=%p Cannot create meta s3 request;"
-            " init callback cannot be used with 'make_meta_request()' function, use 'start_meta_request()' instead",
+            " init callback cannot be used with 'make_meta_request()' function, use 'start_meta_request()' instead.",
             (void *)client);
         aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
         return NULL;
@@ -1224,7 +1222,7 @@ static void s_s3_client_process_work_default(struct aws_s3_client *client) {
         if (meta_request->init_callback) {
             AWS_LOGF_DEBUG(AWS_LS_S3_META_REQUEST, "id=%p Invoking init callback.", (void *)meta_request);
 
-            if (meta_request->init_callback(meta_request, AWS_ERROR_SUCCESS) != AWS_OP_SUCCESS) {
+            if (meta_request->init_callback(meta_request, meta_request->user_data)) {
 
                 int error_code = aws_last_error_or_unknown();
                 AWS_LOGF_ERROR(

--- a/source/s3_copy_object.c
+++ b/source/s3_copy_object.c
@@ -634,8 +634,7 @@ static void s_s3_copy_object_request_finished(
 
             if (error_code == AWS_ERROR_SUCCESS) {
                 needed_response_headers = aws_http_headers_new(meta_request->allocator);
-                const size_t copy_header_count =
-                    sizeof(s_create_multipart_upload_copy_headers) / sizeof(struct aws_byte_cursor);
+                const size_t copy_header_count = AWS_ARRAY_SIZE(s_create_multipart_upload_copy_headers);
 
                 /* Copy any headers now that we'll need for the final, transformed headers later. */
                 for (size_t header_index = 0; header_index < copy_header_count; ++header_index) {

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -231,6 +231,7 @@ int aws_s3_meta_request_init_base(
 
     meta_request->meta_request_level_running_response_sum = NULL;
     meta_request->user_data = options->user_data;
+    meta_request->init_callback = options->init_callback;
     meta_request->shutdown_callback = options->shutdown_callback;
     meta_request->progress_callback = options->progress_callback;
 

--- a/tests/s3_data_plane_tests.c
+++ b/tests/s3_data_plane_tests.c
@@ -583,7 +583,7 @@ static int s_test_s3_client_queue_requests(struct aws_allocator *allocator, void
         aws_s3_request_new(mock_meta_request, 0, 0, 0),
     };
 
-    const uint32_t num_requests = sizeof(requests) / sizeof(struct aws_s3_request *);
+    const uint32_t num_requests = AWS_ARRAY_SIZE(requests);
 
     struct aws_linked_list request_list;
     aws_linked_list_init(&request_list);
@@ -4074,8 +4074,8 @@ static int s_test_s3_range_requests(struct aws_allocator *allocator, void *ctx) 
     struct aws_s3_client *client = NULL;
     ASSERT_SUCCESS(aws_s3_tester_client_new(&tester, &client_options, &client));
 
-    const size_t num_object_names = sizeof(object_names) / sizeof(object_names[0]);
-    const size_t num_ranges = sizeof(ranges) / sizeof(ranges[0]);
+    const size_t num_object_names = AWS_ARRAY_SIZE(object_names);
+    const size_t num_ranges = AWS_ARRAY_SIZE(ranges);
 
     for (size_t object_name_index = 0; object_name_index < num_object_names; ++object_name_index) {
         for (size_t range_index = 0; range_index < num_ranges; ++range_index) {
@@ -4156,7 +4156,7 @@ static int s_test_s3_range_requests(struct aws_allocator *allocator, void *ctx) 
 
                 bool ignore_header = false;
 
-                for (size_t j = 0; j < sizeof(headers_to_ignore) / sizeof(headers_to_ignore[0]); ++j) {
+                for (size_t j = 0; j < AWS_ARRAY_SIZE(headers_to_ignore); ++j) {
                     if (aws_byte_cursor_eq_ignore_case(&headers_to_ignore[j], &verify_header.name)) {
                         ignore_header = true;
                         break;
@@ -4178,7 +4178,7 @@ static int s_test_s3_range_requests(struct aws_allocator *allocator, void *ctx) 
                 struct aws_byte_cursor header_value;
                 ASSERT_SUCCESS(aws_http_headers_get(range_get_headers, verify_header.name, &header_value));
 
-                for (size_t j = 0; j < sizeof(headers_that_should_match) / sizeof(headers_that_should_match[0]); ++j) {
+                for (size_t j = 0; j < AWS_ARRAY_SIZE(headers_that_should_match); ++j) {
                     if (!aws_byte_cursor_eq_ignore_case(&headers_that_should_match[j], &verify_header.name)) {
                         continue;
                     }

--- a/tests/s3_list_objects_tests.c
+++ b/tests/s3_list_objects_tests.c
@@ -120,7 +120,7 @@ static void s_on_list_bucket_page_finished_fn(struct aws_s3_paginator *paginator
         aws_mutex_lock(&test_data->mutex);
         test_data->done = true;
         aws_mutex_unlock(&test_data->mutex);
-        aws_condition_variable_notify_one(&test_data->c_var);
+        aws_condition_variable_notify_all(&test_data->c_var);
     }
 }
 

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -411,7 +411,7 @@ static bool s_s3_tester_have_meta_requests_initialized(void *user_data) {
     return tester->synced_data.meta_requests_initialized;
 }
 
-void aws_s3_tester_wait_for_meta_request_init(struct aws_s3_tester *tester) {
+void aws_s3_tester_wait_for_meta_request_initialized(struct aws_s3_tester *tester) {
     AWS_PRECONDITION(tester);
 
     aws_s3_tester_lock_synced_data(tester);
@@ -1505,7 +1505,7 @@ int aws_s3_tester_send_meta_request(
 
     ASSERT_SUCCESS(aws_s3_client_start_meta_request(client, options));
 
-    aws_s3_tester_wait_for_meta_request_init(tester);
+    aws_s3_tester_wait_for_meta_request_initialized(tester);
 
     if (flags & AWS_S3_TESTER_SEND_META_REQUEST_CANCEL) {
         /* take a random sleep from 0-1 ms. */

--- a/tests/s3_tester.h
+++ b/tests/s3_tester.h
@@ -234,7 +234,7 @@ void aws_s3_meta_request_test_results_clean_up(struct aws_s3_meta_request_test_r
 
 /* Wait for the correct number of aws_s3_tester_notify_meta_request_initialized to be called.
  * Once this returns, the aws_s3_meta_request_test_results.meta_request pointers are all set */
-void aws_s3_tester_wait_for_meta_request_init(struct aws_s3_tester *tester);
+void aws_s3_tester_wait_for_meta_request_initialized(struct aws_s3_tester *tester);
 
 /* Wait for the correct number of aws_s3_tester_notify_meta_request_finished to be called */
 void aws_s3_tester_wait_for_meta_request_finish(struct aws_s3_tester *tester);

--- a/tests/s3_tester.h
+++ b/tests/s3_tester.h
@@ -178,8 +178,6 @@ struct aws_s3_tester_meta_request_options {
     enum aws_s3_tester_sse_type sse_type;
     enum aws_s3_tester_validate_type validate_type;
 
-    uint32_t dont_wait_for_shutdown : 1;
-
     uint32_t mrap_test : 1;
 };
 
@@ -233,11 +231,12 @@ void aws_s3_meta_request_test_results_init(
 
 void aws_s3_meta_request_test_results_clean_up(struct aws_s3_meta_request_test_results *test_meta_request);
 
-/* Wait for the meta_request pointer to be delivered via the init callback. */
-struct aws_s3_meta_request *aws_s3_meta_request_test_results_wait_for_init(
-    struct aws_s3_meta_request_test_results *test_meta_request);
+/* Wait for init_callback to fire.
+ * Once this returns, the results.meta_request pointer is set */
+void aws_s3_meta_request_test_results_wait_for_init(struct aws_s3_meta_request_test_results *test_meta_request);
 
-/* Release the meta_request pointer and wait for its shutdown_callback to fire */
+/* Release the meta_request and wait for its shutdown_callback to fire.
+ * Once this returns, the results.meta_request pointer is NULL*/
 void aws_s3_meta_request_test_results_wait_for_shutdown(struct aws_s3_meta_request_test_results *test_meta_request);
 
 /* Wait for the correct number of aws_s3_tester_notify_meta_request_finished to be called */

--- a/tests/s3_util_tests.c
+++ b/tests/s3_util_tests.c
@@ -58,7 +58,7 @@ static int s_test_s3_replace_quote_entities(struct aws_allocator *allocator, voi
         },
     };
 
-    for (size_t i = 0; i < (sizeof(test_cases) / sizeof(struct replace_quote_entities_test_case)); ++i) {
+    for (size_t i = 0; i < AWS_ARRAY_SIZE(test_cases); ++i) {
         struct replace_quote_entities_test_case *test_case = &test_cases[i];
 
         struct aws_byte_buf result_byte_buf;
@@ -116,7 +116,7 @@ static int s_test_s3_strip_quotes(struct aws_allocator *allocator, void *ctx) {
         },
     };
 
-    for (size_t i = 0; i < (sizeof(test_cases) / sizeof(struct strip_quotes_test_case)); ++i) {
+    for (size_t i = 0; i < AWS_ARRAY_SIZE(test_cases); ++i) {
         struct strip_quotes_test_case *test_case = &test_cases[i];
 
         struct aws_byte_buf result_byte_buf;


### PR DESCRIPTION
**Issue:**
The current API requires users to be VERY CAREFUL to avoid the following race condition:
> If user stores the pointer returned by `aws_s3_client_make_meta_request()`,
> and then accesses the stored pointer from callbacks,
> the callbacks can fire on another thread before this function has returned,
> so the stored pointer doesn't exist yet, and kaboom.

See the race condition being fixed here:
* https://github.com/aws/aws-sdk-cpp/pull/2025


**Description of changes:**
Introduce new API for creating meta-requests, which helps avoid race conditions in user code


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
