### PR TITLE
Fix off-by-one error in calculating the number of parts

### DIFF
--- a/source/s3_util.c
+++ b/source/s3_util.c
@@ -493,7 +493,7 @@ uint32_t aws_s3_get_num_parts(size_t part_size, uint64_t object_range_start, uin
 
     /* If the range has room for a second part, calculate the additional amount of parts. */
     if (second_part_start <= object_range_end) {
-        uint64_t aligned_range_remainder = object_range_end - second_part_start;
+        uint64_t aligned_range_remainder = object_range_end + 1 - second_part_start;
         num_parts += (uint32_t)(aligned_range_remainder / (uint64_t)part_size);
 
         if ((aligned_range_remainder % part_size) > 0) {


### PR DESCRIPTION
When calculating the total number of parts for a given range `start..end` and `part_size`, `end+1` needs to be used instead of `end`. The reason is that the code consistently uses Http Byte ranges, which start at index 0 and end at `ContentLength-1`.

The code ensures that `second_part_start` is aligned at `part_size`, hence the number of remaining chunks is `ceil((end + 1 - second_part_start) / part_size)`.

Resolves #230.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
