### PR TITLE
handle async error for default type

### DIFF
--- a/source/s3_default_meta_request.c
+++ b/source/s3_default_meta_request.c
@@ -29,7 +29,7 @@ static void s_s3_meta_request_default_request_finished(
 
 static struct aws_s3_meta_request_vtable s_s3_meta_request_default_vtable = {
     .update = s_s3_meta_request_default_update,
-    .send_request_finish = aws_s3_meta_request_send_request_finish_default,
+    .send_request_finish = aws_s3_meta_request_send_request_finish_handle_async_error,
     .prepare_request = s_s3_meta_request_default_prepare_request,
     .init_signing_date_time = aws_s3_meta_request_init_signing_date_time_default,
     .sign_request = aws_s3_meta_request_sign_request_default,

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -1087,7 +1087,7 @@ static int s_s3_meta_request_error_code_from_response_body(struct aws_s3_request
     } else {
         /* Check the error code. Map the S3 error code to CRT error code. */
         int error_code = aws_s3_crt_error_code_from_server_error_code_string(error_code_string);
-        if (error_code != AWS_ERROR_S3_INTERNAL_ERROR) {
+        if (error_code == AWS_ERROR_UNKNOWN) {
             /* All error besides of internal error from async error are not recoverable from retry for now. */
             error_code = AWS_ERROR_S3_NON_RECOVERABLE_ASYNC_ERROR;
         }

--- a/source/s3_util.c
+++ b/source/s3_util.c
@@ -65,6 +65,9 @@ const struct aws_byte_cursor g_error_body_xml_name = AWS_BYTE_CUR_INIT_FROM_STRI
 const struct aws_byte_cursor g_code_body_xml_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("Code");
 
 const struct aws_byte_cursor g_s3_internal_error_code = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("InternalError");
+const struct aws_byte_cursor g_s3_slow_down_error_code = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("SlowDown");
+/* The special error code as Asynchronous Error Codes */
+const struct aws_byte_cursor g_s3_internal_errors_code = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("InternalErrors");
 
 const uint32_t g_s3_max_num_upload_parts = 10000;
 const size_t g_s3_min_upload_part_size = MB_TO_BYTES(5);
@@ -548,7 +551,11 @@ void aws_s3_get_part_range(
 }
 
 int aws_s3_crt_error_code_from_server_error_code_string(const struct aws_string *error_code_string) {
-    if (aws_string_eq_byte_cursor(error_code_string, &g_s3_internal_error_code)) {
+    if (aws_string_eq_byte_cursor(error_code_string, &g_s3_slow_down_error_code)) {
+        return AWS_ERROR_S3_SLOW_DOWN;
+    }
+    if (aws_string_eq_byte_cursor(error_code_string, &g_s3_internal_error_code) ||
+        aws_string_eq_byte_cursor(error_code_string, &g_s3_internal_errors_code)) {
         return AWS_ERROR_S3_INTERNAL_ERROR;
     }
     return AWS_ERROR_UNKNOWN;


### PR DESCRIPTION
*Issue #, if available:*

- Handle async error for default type of request. Mostly for copy object used.
- https://aws.amazon.com/premiumsupport/knowledge-center/s3-resolve-200-internalerror/
- We need to handle that for default type as well, since the retry should happen from CRT.

*Description of changes:*

- The list [here](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#S3AsynchronousErrorCodeList) is not complete. S3 can return slowdown with 200 as well.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
