### PR TITLE
Use AWS_ARRAY_SIZE() macro

### DIFF
--- a/source/s3.c
+++ b/source/s3.c
@@ -41,7 +41,7 @@ static struct aws_error_info s_errors[] = {
 
 static struct aws_error_info_list s_error_list = {
     .error_list = s_errors,
-    .count = sizeof(s_errors) / sizeof(struct aws_error_info),
+    .count = AWS_ARRAY_SIZE(s_errors),
 };
 
 static struct aws_log_subject_info s_s3_log_subject_infos[] = {

--- a/source/s3_auto_ranged_put.c
+++ b/source/s3_auto_ranged_put.c
@@ -206,7 +206,7 @@ static int s_load_persistable_state(
     auto_ranged_put->synced_data.list_parts_operation = aws_s3_list_parts_operation_new(allocator, &list_parts_params);
 
     struct aws_http_headers *needed_response_headers = aws_http_headers_new(allocator);
-    const size_t copy_header_count = sizeof(s_create_multipart_upload_copy_headers) / sizeof(struct aws_byte_cursor);
+    const size_t copy_header_count = AWS_ARRAY_SIZE(s_create_multipart_upload_copy_headers);
     struct aws_http_headers *initial_headers =
         aws_http_message_get_headers(auto_ranged_put->base.initial_request_message);
 
@@ -971,8 +971,7 @@ static void s_s3_auto_ranged_put_request_finished(
 
             if (error_code == AWS_ERROR_SUCCESS) {
                 needed_response_headers = aws_http_headers_new(meta_request->allocator);
-                const size_t copy_header_count =
-                    sizeof(s_create_multipart_upload_copy_headers) / sizeof(struct aws_byte_cursor);
+                const size_t copy_header_count = AWS_ARRAY_SIZE(s_create_multipart_upload_copy_headers);
 
                 /* Copy any headers now that we'll need for the final, transformed headers later. */
                 for (size_t header_index = 0; header_index < copy_header_count; ++header_index) {

--- a/source/s3_copy_object.c
+++ b/source/s3_copy_object.c
@@ -634,8 +634,7 @@ static void s_s3_copy_object_request_finished(
 
             if (error_code == AWS_ERROR_SUCCESS) {
                 needed_response_headers = aws_http_headers_new(meta_request->allocator);
-                const size_t copy_header_count =
-                    sizeof(s_create_multipart_upload_copy_headers) / sizeof(struct aws_byte_cursor);
+                const size_t copy_header_count = AWS_ARRAY_SIZE(s_create_multipart_upload_copy_headers);
 
                 /* Copy any headers now that we'll need for the final, transformed headers later. */
                 for (size_t header_index = 0; header_index < copy_header_count; ++header_index) {

--- a/tests/s3_data_plane_tests.c
+++ b/tests/s3_data_plane_tests.c
@@ -583,7 +583,7 @@ static int s_test_s3_client_queue_requests(struct aws_allocator *allocator, void
         aws_s3_request_new(mock_meta_request, 0, 0, 0),
     };
 
-    const uint32_t num_requests = sizeof(requests) / sizeof(struct aws_s3_request *);
+    const uint32_t num_requests = AWS_ARRAY_SIZE(requests);
 
     struct aws_linked_list request_list;
     aws_linked_list_init(&request_list);
@@ -1275,10 +1275,9 @@ static int s_test_s3_get_object_multiple(struct aws_allocator *allocator, void *
 
     struct aws_s3_meta_request *meta_requests[4];
     struct aws_s3_meta_request_test_results meta_request_test_results[4];
-    size_t num_meta_requests = sizeof(meta_requests) / sizeof(struct aws_s3_meta_request *);
+    size_t num_meta_requests = AWS_ARRAY_SIZE(meta_requests);
 
-    ASSERT_TRUE(
-        num_meta_requests == (sizeof(meta_request_test_results) / sizeof(struct aws_s3_meta_request_test_results)));
+    ASSERT_TRUE(num_meta_requests == AWS_ARRAY_SIZE(meta_request_test_results));
 
     struct aws_s3_tester tester;
     AWS_ZERO_STRUCT(tester);
@@ -1684,10 +1683,9 @@ static int s_test_s3_put_object_multiple(struct aws_allocator *allocator, void *
     struct aws_http_message *messages[2];
     struct aws_input_stream *input_streams[2];
     struct aws_byte_buf input_stream_buffers[2];
-    size_t num_meta_requests = sizeof(meta_requests) / sizeof(struct aws_s3_meta_request *);
+    size_t num_meta_requests = AWS_ARRAY_SIZE(meta_requests);
 
-    ASSERT_TRUE(
-        num_meta_requests == (sizeof(meta_request_test_results) / sizeof(struct aws_s3_meta_request_test_results)));
+    ASSERT_TRUE(num_meta_requests == AWS_ARRAY_SIZE(meta_request_test_results));
 
     struct aws_s3_tester tester;
     AWS_ZERO_STRUCT(tester);
@@ -4090,8 +4088,8 @@ static int s_test_s3_range_requests(struct aws_allocator *allocator, void *ctx) 
     struct aws_s3_client *client = NULL;
     ASSERT_SUCCESS(aws_s3_tester_client_new(&tester, &client_options, &client));
 
-    const size_t num_object_names = sizeof(object_names) / sizeof(object_names[0]);
-    const size_t num_ranges = sizeof(ranges) / sizeof(ranges[0]);
+    const size_t num_object_names = AWS_ARRAY_SIZE(object_names);
+    const size_t num_ranges = AWS_ARRAY_SIZE(ranges);
 
     for (size_t object_name_index = 0; object_name_index < num_object_names; ++object_name_index) {
         for (size_t range_index = 0; range_index < num_ranges; ++range_index) {
@@ -4172,7 +4170,7 @@ static int s_test_s3_range_requests(struct aws_allocator *allocator, void *ctx) 
 
                 bool ignore_header = false;
 
-                for (size_t j = 0; j < sizeof(headers_to_ignore) / sizeof(headers_to_ignore[0]); ++j) {
+                for (size_t j = 0; j < AWS_ARRAY_SIZE(headers_to_ignore); ++j) {
                     if (aws_byte_cursor_eq_ignore_case(&headers_to_ignore[j], &verify_header.name)) {
                         ignore_header = true;
                         break;
@@ -4194,7 +4192,7 @@ static int s_test_s3_range_requests(struct aws_allocator *allocator, void *ctx) 
                 struct aws_byte_cursor header_value;
                 ASSERT_SUCCESS(aws_http_headers_get(range_get_headers, verify_header.name, &header_value));
 
-                for (size_t j = 0; j < sizeof(headers_that_should_match) / sizeof(headers_that_should_match[0]); ++j) {
+                for (size_t j = 0; j < AWS_ARRAY_SIZE(headers_that_should_match); ++j) {
                     if (!aws_byte_cursor_eq_ignore_case(&headers_that_should_match[j], &verify_header.name)) {
                         continue;
                     }

--- a/tests/s3_util_tests.c
+++ b/tests/s3_util_tests.c
@@ -58,7 +58,7 @@ static int s_test_s3_replace_quote_entities(struct aws_allocator *allocator, voi
         },
     };
 
-    for (size_t i = 0; i < (sizeof(test_cases) / sizeof(struct replace_quote_entities_test_case)); ++i) {
+    for (size_t i = 0; i < AWS_ARRAY_SIZE(test_cases); ++i) {
         struct replace_quote_entities_test_case *test_case = &test_cases[i];
 
         struct aws_byte_buf result_byte_buf;
@@ -116,7 +116,7 @@ static int s_test_s3_strip_quotes(struct aws_allocator *allocator, void *ctx) {
         },
     };
 
-    for (size_t i = 0; i < (sizeof(test_cases) / sizeof(struct strip_quotes_test_case)); ++i) {
+    for (size_t i = 0; i < AWS_ARRAY_SIZE(test_cases); ++i) {
         struct strip_quotes_test_case *test_case = &test_cases[i];
 
         struct aws_byte_buf result_byte_buf;


### PR DESCRIPTION
Just cleaning up ugly code. We have a macro for this. There weren't any bugs or anything.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
