### PR TITLE
use the builder --coverage instead

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,7 +5,7 @@ on:
 
 
 env:
-  BUILDER_VERSION: v0.9.26
+  BUILDER_VERSION: v0.9.29
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-s3
@@ -21,21 +21,8 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3
-      # CMAKE_C_FLAGS for GCC to enable code coverage information.
-      # COVERAGE_EXTRA_FLAGS="-p" to include path information in the report file name
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
-          ./builder build -p ${{ env.PACKAGE_NAME }} --compiler=gcc-9 --cmake-extra=-DASSERT_LOCK_HELD=ON --cmake-extra=-DCMAKE_C_FLAGS="-fprofile-arcs -ftest-coverage" --cmake-extra=-DCOVERAGE_EXTRA_FLAGS="--preserve-paths --source-prefix `pwd`"
-      # Get test coverage report from CMAKE coverage
-      - name: Ctest Coverage
-        run: |
-          cd build/aws-c-s3
-          ctest -T coverage
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-        # only reports those from source/, the report name will be generated with # to replace /
-          files: "source#*"
+          ./builder build -p ${{ env.PACKAGE_NAME }} --compiler=gcc-9 --cmake-extra=-DASSERT_LOCK_HELD=ON --coverage


### PR DESCRIPTION
- use the builder `--coverage` for the test coverage report


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
