### PR TITLE
Fix overly large s_default_max_part_size constant

### DIFF
--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -68,7 +68,7 @@ const uint32_t g_max_num_connections_per_vip = 10;
  * Default part size is 8 MiB to reach the best performance from the experiments we had.
  * Default max part size is SIZE_MAX on 32bit systems, which is around 4GiB; and 5GiB on a 64bit system.
  *      The server limit is 5GiB, but object size limit is 5TiB for now. We should be good enough for all the cases.
- *      The max number of upload parts is 10000, which limits the object size to 39TiB on 32bit and 50TiB on 64bit.
+ *      The max number of upload parts is 10000, which limits the object size to 39TiB on 32bit and 49TiB on 64bit.
  * TODO Provide more information on other values.
  */
 static const size_t s_default_part_size = 8 * 1024 * 1024;

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -65,15 +65,14 @@ const uint32_t g_num_conns_per_vip_meta_request_look_up[AWS_S3_META_REQUEST_TYPE
 const uint32_t g_max_num_connections_per_vip = 10;
 
 /**
- * Default part size is 8 MB to reach the best performance from the experiments we had.
- * Default max part size is SIZE_MAX at 32bit build, which is around 4GB, which is 5GB at 64bit build.
- *      The server limit is 5GB, but object size limit is 5TB for now. We should be good enough for all the case.
- *      For upload, the max number of parts is 10000, which will limits the object size to 40TB for 32bit and 50TB for
- *      64bit.
+ * Default part size is 8 MiB to reach the best performance from the experiments we had.
+ * Default max part size is SIZE_MAX at 32bit build, which is around 4GiB, and 5GiB at 64bit build.
+ *      The server limit is 5GiB, but object size limit is 5TiB for now. We should be good enough for all the cases.
+ *      The max number of upload parts is 10000, which limits the object size to 39TiB on 32bit and 50TiB on 64bit.
  * TODO Provide more information on other values.
  */
 static const size_t s_default_part_size = 8 * 1024 * 1024;
-static const uint64_t s_default_max_part_size = SIZE_MAX < 5000000000000ULL ? SIZE_MAX : 5000000000000ULL;
+static const uint64_t s_default_max_part_size = SIZE_MAX < 5368709120ULL ? SIZE_MAX : 5368709120ULL;
 static const double s_default_throughput_target_gbps = 10.0;
 static const uint32_t s_default_max_retries = 5;
 static size_t s_dns_host_address_ttl_seconds = 5 * 60;

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -66,7 +66,7 @@ const uint32_t g_max_num_connections_per_vip = 10;
 
 /**
  * Default part size is 8 MiB to reach the best performance from the experiments we had.
- * Default max part size is SIZE_MAX at 32bit build, which is around 4GiB, and 5GiB at 64bit build.
+ * Default max part size is SIZE_MAX on 32bit systems, which is around 4GiB; and 5GiB on a 64bit system.
  *      The server limit is 5GiB, but object size limit is 5TiB for now. We should be good enough for all the cases.
  *      The max number of upload parts is 10000, which limits the object size to 39TiB on 32bit and 50TiB on 64bit.
  * TODO Provide more information on other values.


### PR DESCRIPTION
This set the maximum part size on 64bit systems to 5*10^12 B, which is about 4.55 TiB.

Also update the comments for the estimations:
- on 32bit, with SIZE_MAX=2^32-1, the object size is 4294967295 * 10000 ~= 39.06 TiB;
- on 64bit, the object size is 5*2^30 * 10000 ~= 48.82 Tib.

Use the published maximum part size of 5GiB [1] on 64-bit systems.

 [1] https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
