### PR TITLE
Fix Host header not including port

### DIFF
--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -396,7 +396,7 @@ struct aws_s3_meta_request_options {
      * Optional.
      * Endpoint override for request. Can be used to override scheme and port of
      * the endpoint.
-     * There is some overlap between Host header and Endpoint and cornet cases
+     * There is some overlap between Host header and Endpoint and corner cases
      * are handled as follows:
      * - Only Host header is set - Host is used to construct endpoint. https is
      *   default with corresponding port

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -395,7 +395,7 @@ struct aws_s3_meta_request_options {
     /**
      * Optional.
      * Endpoint override for request. Can be used to override scheme and port of
-     * the endpoint. 
+     * the endpoint.
      * There is some overlap between Host header and Endpoint and cornet cases
      * are handled as follows:
      * - Only Host header is set - Host is used to construct endpoint. https is

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -394,9 +394,16 @@ struct aws_s3_meta_request_options {
 
     /**
      * Optional.
-     * The endpoint for the meta request to connect to. If not set, then tls settings from client will
-     * determine the port, and host header from `message` will determine the host for the connection.
-     * Note: must match the host header from `message`
+     * Endpoint override for request. Can be used to override scheme and port of
+     * the endpoint. 
+     * There is some overlap between Host header and Endpoint and cornet cases
+     * are handled as follows:
+     * - Only Host header is set - Host is used to construct endpoint. https is
+     *   default with corresponding port
+     * - Only endpoint is set - Host header is created from endpoint. Port and
+     *   Scheme from endpoint is used.
+     * - Both Host and Endpoint is set - Host header must match Authority of
+     *   Endpoint uri. Port and Scheme from endpoint is used.
      */
     struct aws_uri *endpoint;
 

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -636,19 +636,20 @@ struct aws_s3_request *aws_s3_client_dequeue_request_threaded(struct aws_s3_clie
     return request;
 }
 
-int s_update_host_header_based_on_endpoint_override(const struct aws_s3_client *client,
-                                                    struct aws_http_headers *message_headers, 
-                                                    const struct aws_uri *endpoint) {
+int s_update_host_header_based_on_endpoint_override(
+    const struct aws_s3_client *client,
+    struct aws_http_headers *message_headers,
+    const struct aws_uri *endpoint) {
     AWS_PRECONDITION(message_headers);
 
-    const struct aws_byte_cursor *endpoint_authority = 
-        endpoint == NULL ? NULL : aws_uri_authority(endpoint);
+    const struct aws_byte_cursor *endpoint_authority = endpoint == NULL ? NULL : aws_uri_authority(endpoint);
 
     if (!aws_http_headers_has(message_headers, g_host_header_name)) {
         if (endpoint_authority == NULL) {
             AWS_LOGF_ERROR(
                 AWS_LS_S3_CLIENT,
-                "id=%p Cannot create meta s3 request; message provided in options does not have either 'Host' header set or endpoint override.",
+                "id=%p Cannot create meta s3 request; message provided in options does not have either 'Host' header "
+                "set or endpoint override.",
                 (void *)client);
             return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
         }
@@ -665,21 +666,20 @@ int s_update_host_header_based_on_endpoint_override(const struct aws_s3_client *
     struct aws_byte_cursor host_value;
     if (aws_http_headers_get(message_headers, g_host_header_name, &host_value)) {
         AWS_LOGF_ERROR(
-                AWS_LS_S3_CLIENT,
-                "id=%p Cannot create meta s3 request; message provided in options does not have a 'Host' header.",
-                (void *)client);
+            AWS_LS_S3_CLIENT,
+            "id=%p Cannot create meta s3 request; message provided in options does not have a 'Host' header.",
+            (void *)client);
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
-    if (endpoint_authority != NULL &&
-        !aws_byte_cursor_eq(&host_value, endpoint_authority)) {
+    if (endpoint_authority != NULL && !aws_byte_cursor_eq(&host_value, endpoint_authority)) {
         AWS_LOGF_ERROR(
-                AWS_LS_S3_CLIENT,
-                "id=%p Cannot create meta s3 request; host header value " PRInSTR 
-                " does not match endpoint override " PRInSTR,
-                (void *)client,
-                AWS_BYTE_CURSOR_PRI(host_value),
-                AWS_BYTE_CURSOR_PRI(*endpoint_authority));
+            AWS_LS_S3_CLIENT,
+            "id=%p Cannot create meta s3 request; host header value " PRInSTR
+            " does not match endpoint override " PRInSTR,
+            (void *)client,
+            AWS_BYTE_CURSOR_PRI(host_value),
+            AWS_BYTE_CURSOR_PRI(*endpoint_authority));
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
@@ -774,7 +774,7 @@ struct aws_s3_meta_request *aws_s3_client_make_meta_request(
         }
     }
 
-    if(s_update_host_header_based_on_endpoint_override(client, message_headers, options->endpoint)) {
+    if (s_update_host_header_based_on_endpoint_override(client, message_headers, options->endpoint)) {
         return NULL;
     }
 
@@ -807,7 +807,7 @@ struct aws_s3_meta_request *aws_s3_client_make_meta_request(
                 AWS_BYTE_CURSOR_PRI(*scheme));
             aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
             return NULL;
-        } 
+        }
 
         port = aws_uri_port(options->endpoint);
     }
@@ -824,14 +824,15 @@ struct aws_s3_meta_request *aws_s3_client_make_meta_request(
     /* BEGIN CRITICAL SECTION */
     {
         aws_s3_client_lock_synced_data(client);
-        
-        struct aws_uri host_uri; 
+
+        struct aws_uri host_uri;
         if (aws_uri_init_parse(&host_uri, client->allocator, &host_header_value)) {
             error_occurred = true;
             goto unlock;
         }
 
-        struct aws_string *endpoint_host_name = aws_string_new_from_cursor(client->allocator, aws_uri_host_name(&host_uri));
+        struct aws_string *endpoint_host_name =
+            aws_string_new_from_cursor(client->allocator, aws_uri_host_name(&host_uri));
         aws_uri_clean_up(&host_uri);
 
         struct aws_s3_endpoint *endpoint = NULL;

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -671,7 +671,7 @@ int s_update_host_header_based_on_endpoint_override(const struct aws_s3_client *
         AWS_LOGF_ERROR(
                 AWS_LS_S3_CLIENT,
                 "id=%p Cannot create meta s3 request; host header value " PRInSTR 
-                " does not match endpoint override ." PRInSTR,
+                " does not match endpoint override " PRInSTR,
                 (void *)client,
                 AWS_BYTE_CURSOR_PRI(host_value),
                 AWS_BYTE_CURSOR_PRI(*endpoint_authority));

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -840,7 +840,7 @@ struct aws_s3_meta_request *aws_s3_client_make_meta_request(
                 goto unlock;
             }
 
-            aws_string_new_from_cursor(client->allocator, aws_uri_host_name(&host_uri));
+            endpoint_host_name = aws_string_new_from_cursor(client->allocator, aws_uri_host_name(&host_uri));
             aws_uri_clean_up(&host_uri);
         }
 

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -637,9 +637,9 @@ struct aws_s3_request *aws_s3_client_dequeue_request_threaded(struct aws_s3_clie
 }
 
 /*
-* There is currently some overlap between user provided Host header and endpoint
-* override. This function handles the corner cases for when either or both are provided.
-*/
+ * There is currently some overlap between user provided Host header and endpoint
+ * override. This function handles the corner cases for when either or both are provided.
+ */
 int s_apply_endpoint_override(
     const struct aws_s3_client *client,
     struct aws_http_headers *message_headers,
@@ -829,9 +829,7 @@ struct aws_s3_meta_request *aws_s3_client_make_meta_request(
     {
         aws_s3_client_lock_synced_data(client);
 
-
-
-        struct aws_string *endpoint_host_name = NULL; 
+        struct aws_string *endpoint_host_name = NULL;
 
         if (options->endpoint != NULL) {
             endpoint_host_name = aws_string_new_from_cursor(client->allocator, aws_uri_host_name(options->endpoint));

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -805,7 +805,13 @@ struct aws_s3_meta_request *aws_s3_client_make_meta_request(
     {
         aws_s3_client_lock_synced_data(client);
 
-        struct aws_string *endpoint_host_name = aws_string_new_from_cursor(client->allocator, &host_header_value);
+        
+        struct aws_uri host_uri; 
+        aws_uri_init_parse(&host_uri, client->allocator, &host_header_value);
+
+        struct aws_string *endpoint_host_name = aws_string_new_from_cursor(client->allocator,
+            aws_uri_host_name(&host_uri));
+        aws_uri_clean_up(&host_uri);
 
         struct aws_s3_endpoint *endpoint = NULL;
         struct aws_hash_element *endpoint_hash_element = NULL;

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -670,8 +670,11 @@ int s_update_host_header_based_on_endpoint_override(const struct aws_s3_client *
     if (endpoint_authority != NULL && !aws_byte_cursor_eq(&host_value, endpoint_authority)) {
         AWS_LOGF_ERROR(
                 AWS_LS_S3_CLIENT,
-                "id=%p Cannot create meta s3 request; host header does not match endpoint override.",
-                (void *)client);
+                "id=%p Cannot create meta s3 request; host header value " PRInSTR 
+                " does not match endpoint override ." PRInSTR,
+                (void *)client,
+                AWS_BYTE_CURSOR_PRI(host_value),
+                AWS_BYTE_CURSOR_PRI(*endpoint_authority));
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -660,10 +660,18 @@ int s_update_host_header_based_on_endpoint_override(const struct aws_s3_client *
 
     struct aws_byte_cursor host_value;
     if (aws_http_headers_get(message_headers, g_host_header_name, &host_value)) {
+        AWS_LOGF_ERROR(
+                AWS_LS_S3_CLIENT,
+                "id=%p Cannot create meta s3 request; message provided in options does not have a 'Host' header.",
+                (void *)client);
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
     if (endpoint_authority != NULL && !aws_byte_cursor_eq(&host_value, endpoint_authority)) {
+        AWS_LOGF_ERROR(
+                AWS_LS_S3_CLIENT,
+                "id=%p Cannot create meta s3 request; host header does not match endpoint override.",
+                (void *)client);
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 

--- a/tests/s3_mock_server_tests.c
+++ b/tests/s3_mock_server_tests.c
@@ -158,7 +158,7 @@ TEST_CASE(get_object_modified_mock_server) {
     struct aws_s3_client *client = NULL;
     ASSERT_SUCCESS(aws_s3_tester_client_new(&tester, &client_options, &client));
 
-    /* Check the mock server READEME/GetObject Response for the response that will be received. */
+    /* Check the mock server README/GetObject Response for the response that will be received. */
     struct aws_byte_cursor object_path = aws_byte_cursor_from_c_str("/get_object_modified");
 
     struct aws_s3_tester_meta_request_options get_options = {

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -1233,7 +1233,7 @@ int aws_s3_tester_send_meta_request_with_options(
 
         struct aws_string *host_name = NULL;
         if (options->mock_server) {
-            const struct aws_byte_cursor *host_cursor = aws_uri_host_name(&mock_server);
+            const struct aws_byte_cursor *host_cursor = aws_uri_authority(&mock_server);
             host_name = aws_string_new_from_cursor(allocator, host_cursor);
         } else if (options->mrap_test) {
             host_name = aws_string_new_from_cursor(allocator, &g_test_mrap_endpoint);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There is some overlap between meta request endpoint and Host header. Clarified the docs what happens depending on which one is used. 
Fix logic comparing the two if both are set with ports. 
Made Host header optional if endpoint is provided


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
