### PR TITLE
fix test_s3_range_requests

### DIFF
--- a/tests/s3_data_plane_tests.c
+++ b/tests/s3_data_plane_tests.c
@@ -4345,6 +4345,20 @@ static int s_test_s3_range_requests(struct aws_allocator *allocator, void *ctx) 
                 struct aws_http_header header;
 
                 ASSERT_SUCCESS(aws_http_headers_get_index(range_get_headers, i, &header));
+                bool ignore_header = false;
+
+                /* If the ignore header doesn't exist in the verify_range_get_headers, ignore it here. */
+                for (size_t j = 0; j < AWS_ARRAY_SIZE(headers_to_ignore); ++j) {
+                    if (aws_byte_cursor_eq_ignore_case(&headers_to_ignore[j], &header.name)) {
+                        ignore_header = true;
+                        break;
+                    }
+                }
+
+                if (ignore_header) {
+                    aws_http_headers_erase(range_get_headers, header.name);
+                    continue;
+                }
 
                 AWS_LOGF_INFO(AWS_LS_S3_GENERAL, "Left over header: " PRInSTR, AWS_BYTE_CURSOR_PRI(header.name));
             }

--- a/tests/s3_data_plane_tests.c
+++ b/tests/s3_data_plane_tests.c
@@ -4308,7 +4308,7 @@ static int s_test_s3_range_requests(struct aws_allocator *allocator, void *ctx) 
                 }
 
                 if (ignore_header) {
-                    aws_http_headers_erase(range_get_headers, verify_header.name);
+                    ASSERT_SUCCESS(aws_http_headers_erase(range_get_headers, verify_header.name));
                     continue;
                 }
 
@@ -4338,7 +4338,7 @@ static int s_test_s3_range_requests(struct aws_allocator *allocator, void *ctx) 
                     ASSERT_TRUE(aws_byte_cursor_eq(&verify_header.value, &header_value));
                 }
 
-                aws_http_headers_erase(range_get_headers, verify_header.name);
+                ASSERT_SUCCESS(aws_http_headers_erase(range_get_headers, verify_header.name));
             }
 
             for (size_t i = 0; i < aws_http_headers_count(range_get_headers); ++i) {
@@ -4356,7 +4356,7 @@ static int s_test_s3_range_requests(struct aws_allocator *allocator, void *ctx) 
                 }
 
                 if (ignore_header) {
-                    aws_http_headers_erase(range_get_headers, header.name);
+                    ASSERT_SUCCESS(aws_http_headers_erase(range_get_headers, header.name));
                     continue;
                 }
 


### PR DESCRIPTION
- the test logic is wrong.
- It checks the `verify_range_get_headers` matches `range_get_headers` and ignore some headers.
- But it only iterates through `verify_range_get_headers` to erase the ignored headers from `range_get_headers`
- So, if the ignore header only exist in `range_get_headers` instead of `verify_range_get_headers`, it will not get ignored correctly


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
