### PR TITLE
Update dashboard stack tsnode version

### DIFF
--- a/benchmarks/dashboard-stack/package.json
+++ b/benchmarks/dashboard-stack/package.json
@@ -17,7 +17,7 @@
     "aws-cdk": "^1.20.0",
     "jest": "^27.2.1",
     "ts-jest": "^27.0.5",
-    "ts-node": "^9.0.0",
+    "ts-node": "^10.9.1",
     "typescript": "^4.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
*Description of changes:*
- The codebuild job was dashboard is failing due to an outdated tsnode version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
