### PR TITLE
Add defaults to detect dead connections.

### DIFF
--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -90,6 +90,7 @@ struct aws_s3_endpoint_options {
 
     /**
      * Optional.
+     * If NULL, default values are used.
      * Configuration options for connection monitoring.
      * If the transfer speed falls below the specified minimum_throughput_bytes_per_second, the operation is aborted.
      */

--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -90,7 +90,6 @@ struct aws_s3_endpoint_options {
 
     /**
      * Optional.
-     * If NULL, default values are used.
      * Configuration options for connection monitoring.
      * If the transfer speed falls below the specified minimum_throughput_bytes_per_second, the operation is aborted.
      */
@@ -248,11 +247,11 @@ struct aws_s3_client {
     struct aws_s3_tcp_keep_alive_options *tcp_keep_alive_options;
 
     /**
-     * Optional.
      * Configuration options for connection monitoring.
      * If the transfer speed falls below the specified minimum_throughput_bytes_per_second, the operation is aborted.
+     * If user passes in NULL, default values are used.
      */
-    struct aws_http_connection_monitoring_options *monitoring_options;
+    struct aws_http_connection_monitoring_options monitoring_options;
 
     /* tls options from proxy environment settings. */
     struct aws_tls_connection_options *proxy_ev_tls_options;

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -266,6 +266,7 @@ struct aws_s3_client_config {
      * Optional.
      * Configuration options for connection monitoring.
      * If the transfer speed falls below the specified minimum_throughput_bytes_per_second, the operation is aborted.
+     * If set to NULL, default values are used.
      */
     struct aws_http_connection_monitoring_options *monitoring_options;
 

--- a/tests/s3_data_plane_tests.c
+++ b/tests/s3_data_plane_tests.c
@@ -92,7 +92,7 @@ static int s_test_s3_client_monitoring_options_override(struct aws_allocator *al
     struct aws_s3_client *client = aws_s3_client_new(allocator, &client_config);
 
     ASSERT_TRUE(
-        client->monitoring_options->minimum_throughput_bytes_per_second ==
+        client->monitoring_options.minimum_throughput_bytes_per_second ==
         client_config.monitoring_options->minimum_throughput_bytes_per_second);
 
     aws_s3_client_release(client);


### PR DESCRIPTION
We have default timeouts when establishing a connection, but nothing to tell us if a once-good connection goes bad.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
