### PR TITLE
Fix one byte range handling

### DIFF
--- a/source/s3_util.c
+++ b/source/s3_util.c
@@ -478,10 +478,6 @@ int aws_s3_parse_content_length_response_header(
 }
 
 uint32_t aws_s3_get_num_parts(size_t part_size, uint64_t object_range_start, uint64_t object_range_end) {
-    if ((object_range_start - object_range_end) == 0ULL) {
-        return 0;
-    }
-
     uint32_t num_parts = 1;
 
     uint64_t first_part_size = part_size;

--- a/source/s3_util.c
+++ b/source/s3_util.c
@@ -478,6 +478,9 @@ int aws_s3_parse_content_length_response_header(
 }
 
 uint32_t aws_s3_get_num_parts(size_t part_size, uint64_t object_range_start, uint64_t object_range_end) {
+    if ((object_range_start - object_range_end) == 0ULL) {
+        return 0;
+    }
 
     uint32_t num_parts = 1;
 

--- a/source/s3_util.c
+++ b/source/s3_util.c
@@ -478,9 +478,6 @@ int aws_s3_parse_content_length_response_header(
 }
 
 uint32_t aws_s3_get_num_parts(size_t part_size, uint64_t object_range_start, uint64_t object_range_end) {
-    if ((object_range_start - object_range_end) == 0ULL) {
-        return 0;
-    }
 
     uint32_t num_parts = 1;
 

--- a/tests/s3_data_plane_tests.c
+++ b/tests/s3_data_plane_tests.c
@@ -4292,6 +4292,9 @@ static int s_test_s3_range_requests(struct aws_allocator *allocator, void *ctx) 
         // No range at all.
         {0, NULL},
 
+        // Single byte range.
+        AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("bytes=8-8"),
+
         // First 8K.  8K < client's 16K part size.
         AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("bytes=0-8191"),
 

--- a/tests/s3_util_tests.c
+++ b/tests/s3_util_tests.c
@@ -347,7 +347,7 @@ static int s_test_s3_get_num_parts_and_get_part_range(struct aws_allocator *allo
             s_validate_part_ranges(object_range_start, object_range_end, part_size, expected_num_parts, part_ranges));
     }
 
-    /* Tiny range corner cases. */
+    /* 1 byte range corner case. */
     {
         const uint32_t expected_num_parts = 1;
         const uint64_t object_range_start = 8;

--- a/tests/s3_util_tests.c
+++ b/tests/s3_util_tests.c
@@ -347,6 +347,20 @@ static int s_test_s3_get_num_parts_and_get_part_range(struct aws_allocator *allo
             s_validate_part_ranges(object_range_start, object_range_end, part_size, expected_num_parts, part_ranges));
     }
 
+    /* Tiny range corner cases. */
+    {
+        const uint32_t expected_num_parts = 1;
+        const uint64_t object_range_start = 8;
+        const uint64_t object_range_end = 8;
+
+        const uint64_t part_ranges[] = { 8, 8 };
+
+        ASSERT_TRUE(aws_s3_get_num_parts(part_size, object_range_start, object_range_end) == expected_num_parts);
+
+        ASSERT_SUCCESS(
+            s_validate_part_ranges(object_range_start, object_range_end, part_size, expected_num_parts, part_ranges));
+    }
+
     return 0;
 }
 

--- a/tests/s3_util_tests.c
+++ b/tests/s3_util_tests.c
@@ -353,7 +353,7 @@ static int s_test_s3_get_num_parts_and_get_part_range(struct aws_allocator *allo
         const uint64_t object_range_start = 8;
         const uint64_t object_range_end = 8;
 
-        const uint64_t part_ranges[] = { 8, 8 };
+        const uint64_t part_ranges[] = {8, 8};
 
         ASSERT_TRUE(aws_s3_get_num_parts(part_size, object_range_start, object_range_end) == expected_num_parts);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
s3 ranged are inclusive, so range of 8-8 actually has a length of 1 byte, but code incorrectly assumed that it is 0 bytes. this change fixes the issue to handle that range as 1 part


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
