### PR TITLE
Fix bug when Range: bytes=0-0

### DIFF
--- a/include/aws/s3/private/s3_auto_ranged_get.h
+++ b/include/aws/s3/private/s3_auto_ranged_get.h
@@ -20,10 +20,12 @@ struct aws_s3_auto_ranged_get {
     enum aws_s3_checksum_algorithm validation_algorithm;
     /* Members to only be used when the mutex in the base type is locked. */
     struct {
-        /* The starting byte of the data that we will be retrieved from the object.*/
+        /* The starting byte of the data that we will be retrieved from the object.
+         * (ignore this if object_range_empty) */
         uint64_t object_range_start;
 
-        /* The last byte of the data that will be retrieved from the object.*/
+        /* The last byte of the data that will be retrieved from the object.
+         * (ignore this if object_range_empty) */
         uint64_t object_range_end;
 
         /* The total number of parts that are being used in downloading the object range. Note that "part" here
@@ -37,6 +39,10 @@ struct aws_s3_auto_ranged_get {
         uint32_t num_parts_checksum_validated;
 
         uint32_t object_range_known : 1;
+
+        /* True if object_range_known, and it's found to be empty.
+         * If this is true, ignore object_range_start and object_range_end */
+        uint32_t object_range_empty : 1;
         uint32_t head_object_sent : 1;
         uint32_t head_object_completed : 1;
         uint32_t get_without_range_sent : 1;

--- a/source/s3_auto_ranged_get.c
+++ b/source/s3_auto_ranged_get.c
@@ -196,8 +196,7 @@ static bool s_s3_auto_ranged_get_update(
             }
 
             /* If the object range is known and that range is empty, then we have an empty file to request. */
-            if (auto_ranged_get->synced_data.object_range_start == 0 &&
-                auto_ranged_get->synced_data.object_range_end == 0) {
+            if (auto_ranged_get->synced_data.object_range_empty != 0) {
                 if (auto_ranged_get->synced_data.get_without_range_sent) {
                     if (auto_ranged_get->synced_data.get_without_range_completed) {
                         goto no_work_remaining;
@@ -653,6 +652,7 @@ update_synced_data:
             AWS_ASSERT(!auto_ranged_get->synced_data.object_range_known);
 
             auto_ranged_get->synced_data.object_range_known = true;
+            auto_ranged_get->synced_data.object_range_empty = (total_content_length == 0);
             auto_ranged_get->synced_data.object_range_start = object_range_start;
             auto_ranged_get->synced_data.object_range_end = object_range_end;
             auto_ranged_get->synced_data.total_num_parts =

--- a/tests/s3_data_plane_tests.c
+++ b/tests/s3_data_plane_tests.c
@@ -4295,6 +4295,9 @@ static int s_test_s3_range_requests(struct aws_allocator *allocator, void *ctx) 
         // Single byte range.
         AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("bytes=8-8"),
 
+        // Single byte range (first byte).
+        AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("bytes=0-0"),
+
         // First 8K.  8K < client's 16K part size.
         AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("bytes=0-8191"),
 


### PR DESCRIPTION
**Issue**:
GetObject request with range 0-0 returned empty body, but a body with 1 byte is expected.

**Investigation:**
The bug was due to code which assumed that, if an internal `range_start` and `range_end` variable were both 0, it was because those variables never got set, because the object was found to be empty.

**Description of changes:**
Add separate bool to indicate whether the object is found to be empty.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
