### PR TITLE
Fix test helper follow up

### DIFF
--- a/tests/test_helper/README.md
+++ b/tests/test_helper/README.md
@@ -4,7 +4,7 @@ To use this script, you must have AWS credentials with permission to create and 
 
 To create the S3 buckets and objects that tests will use:
 
-``` sh
+```sh
 pip3 install boto3
 export CRT_S3_TEST_BUCKET_NAME=<bucket_name>
 python3 test_helper.py init
@@ -14,7 +14,7 @@ cd aws-c-s3/build/tests && ctest
 
 To clean up the S3 buckets created
 
-``` sh
+```sh
 export CRT_S3_TEST_BUCKET_NAME=<bucket_name>
 python3 test_helper.py clean
 ```
@@ -23,22 +23,22 @@ python3 test_helper.py clean
 
 ### `init` action
 
-- Create `<BUCKET_NAME>` in us-west-2.
-- Add the lifecyle to automatic clean up the `upload/` after one day
-- Upload files:
-  - `pre-existing-10MB-aes256-c` [SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html#sse-c-highlights) encrypted fille
-  - `pre-existing-10MB-aes256` [SSE-S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-s3-encryption.html) encrypted fille
-  - `pre-existing-10MB-kms` [SSE-KMS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html) encrypted fille
-  - `pre-existing-10MB`
-  - `pre-existing-1MB`
-  - `pre-existing-empty`
-- Create `<BUCKET_NAME>-public` in us-west-2
-- Upload files:
-  - `pre-existing-1MB` 1MB file with public read access.
+* Create `<BUCKET_NAME>` in us-west-2.
+* Add the lifecyle to automatic clean up the `upload/` after one day
+* Upload files:
+  + `pre-existing-10MB-aes256-c` [SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html#sse-c-highlights) encrypted fille
+  + `pre-existing-10MB-aes256` [SSE-S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-s3-encryption.html) encrypted fille
+  + `pre-existing-10MB-kms` [SSE-KMS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html) encrypted fille
+  + `pre-existing-10MB`
+  + `pre-existing-1MB`
+  + `pre-existing-empty`
+* Create `<BUCKET_NAME>-public` in us-west-2
+* Upload files:
+  + `pre-existing-1MB` 1MB file with public read access.
 
 ### `clean` action
 
-- Delete the `<BUCKET_NAME>` and `<BUCKET_NAME>-public` and every object inside them
+* Delete the `<BUCKET_NAME>` and `<BUCKET_NAME>-public` and every object inside them
 
 ## BUCKET_NAME
 
@@ -46,11 +46,12 @@ You can specify the bucket name to be created either by passing argument to the 
 
 ## Notes
 
-- The MRAP tests are not included in this script, and it's disabled by default. To run those tests, you will need to create a MRAP access point with the buckets have `pre-existing-1MB` in it. Then update `g_test_mrap_endpoint` to the uri of the MRAP endpoint and build with `-DENABLE_MRAP_TESTS=true`.
-- To run tests in tests/s3_mock_server_tests.c, initialize the mock S3 server first from [here](./../mock_s3_server/). And build your cmake project with `-ENABLE_MOCK_SERVER_TESTS=true`
-- Note: If you are not at the aws-common-runtime AWS team account, you must set environment variable `CRT_S3_TEST_BUCKET_NAME` to the bucket created before running the test.
+* The MRAP tests are not included in this script, and it's disabled by default. To run those tests, you will need to create a MRAP access point with the buckets have `pre-existing-1MB` in it. Then update `g_test_mrap_endpoint` to the uri of the MRAP endpoint and build with `-DENABLE_MRAP_TESTS=true`.
+* To run tests in tests/s3_mock_server_tests.c, initialize the mock S3 server first from [here](./../mock_s3_server/). And build your cmake project with `-ENABLE_MOCK_SERVER_TESTS=true`
+* Note: If you are not at the aws-common-runtime AWS team account, you must set environment variable `CRT_S3_TEST_BUCKET_NAME` to the bucket created before running the test.
+* When you see error with "Check your account level S3 settings, public access may be blocked.", Check https://docs.aws.amazon.com/AmazonS3/latest/userguide/configuring-block-public-access-account.html to set `BlockPublicAcls` to false, which enables public read of the object with `public-read` ACL in the bucket.
 
 ## TODO
 
-- Automatic the mrap creation
-- Instead of hard-coded path and region, make it configurable and pick up from tests.
+* Automatic the mrap creation
+* Instead of hard-coded path and region, make it configurable and pick up from tests.

--- a/tests/test_helper/test_helper.py
+++ b/tests/test_helper/test_helper.py
@@ -140,9 +140,6 @@ def create_bucket_with_public_object():
             Bucket=PUBLIC_BUCKET_NAME,
             PublicAccessBlockConfiguration={
                 'BlockPublicAcls': False,
-                'IgnorePublicAcls': False,
-                'BlockPublicPolicy': False,
-                'RestrictPublicBuckets': False
             }
         )
         print(f"Bucket {PUBLIC_BUCKET_NAME} created", file=sys.stderr)

--- a/tests/test_helper/test_helper.py
+++ b/tests/test_helper/test_helper.py
@@ -167,7 +167,7 @@ def cleanup(bucket_name):
 if args.action == 'init':
     try:
         print(BUCKET_NAME + " " + PUBLIC_BUCKET_NAME + " initializing...")
-        # create_bucket_with_lifecycle()
+        create_bucket_with_lifecycle()
         create_bucket_with_public_object()
         if os.environ.get('CRT_S3_TEST_BUCKET_NAME') != BUCKET_NAME:
             print(

--- a/tests/test_helper/test_helper.py
+++ b/tests/test_helper/test_helper.py
@@ -132,7 +132,19 @@ def create_bucket_with_lifecycle():
 def create_bucket_with_public_object():
     try:
         s3_client.create_bucket(Bucket=PUBLIC_BUCKET_NAME,
-                                CreateBucketConfiguration={'LocationConstraint': REGION})
+                                CreateBucketConfiguration={
+                                    'LocationConstraint': REGION},
+                                ObjectOwnership='ObjectWriter'
+                                )
+        s3_client.put_public_access_block(
+            Bucket=PUBLIC_BUCKET_NAME,
+            PublicAccessBlockConfiguration={
+                'BlockPublicAcls': False,
+                'IgnorePublicAcls': False,
+                'BlockPublicPolicy': False,
+                'RestrictPublicBuckets': False
+            }
+        )
         print(f"Bucket {PUBLIC_BUCKET_NAME} created", file=sys.stderr)
         put_pre_existing_objects(
             1*MB, 'pre-existing-1MB', bucket=PUBLIC_BUCKET_NAME, public_read=True)
@@ -155,7 +167,7 @@ def cleanup(bucket_name):
 if args.action == 'init':
     try:
         print(BUCKET_NAME + " " + PUBLIC_BUCKET_NAME + " initializing...")
-        create_bucket_with_lifecycle()
+        # create_bucket_with_lifecycle()
         create_bucket_with_public_object()
         if os.environ.get('CRT_S3_TEST_BUCKET_NAME') != BUCKET_NAME:
             print(


### PR DESCRIPTION
- Keep all public access block besides of the `BlockPublicAcls`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
