### PR TITLE
Move total_num_parts to non synced data.

### DIFF
--- a/include/aws/s3/private/s3_auto_ranged_put.h
+++ b/include/aws/s3/private/s3_auto_ranged_put.h
@@ -52,7 +52,8 @@ struct aws_s3_auto_ranged_put {
     struct {
         /*
          * Start index of skipping parts.
-         * This is used to keep track of how many parts have been read from input steam and where to try to start skipping parts from.
+         * This is used to keep track of how many parts have been read from input steam and where to try to start
+         * skipping parts from.
          */
         uint32_t part_index_for_skipping;
     } prepare_data;

--- a/include/aws/s3/private/s3_auto_ranged_put.h
+++ b/include/aws/s3/private/s3_auto_ranged_put.h
@@ -33,7 +33,7 @@ struct aws_s3_auto_ranged_put {
 
     /* Note: total num parts is known only if content-length is known,
     otherwise it will be 0. */
-    uint32_t total_num_parts;
+    uint32_t total_num_parts_from_content_length;
 
     /* Only meant for use in the update function, which is never called concurrently. */
     struct {

--- a/include/aws/s3/private/s3_auto_ranged_put.h
+++ b/include/aws/s3/private/s3_auto_ranged_put.h
@@ -31,6 +31,10 @@ struct aws_s3_auto_ranged_put {
     uint64_t content_length;
     bool has_content_length;
 
+    /* Note: total num parts is known only if content-length is known,
+    otherwise it will be 0. */
+    uint32_t total_num_parts;
+
     /* Only meant for use in the update function, which is never called concurrently. */
     struct {
         /*
@@ -66,9 +70,6 @@ struct aws_s3_auto_ranged_put {
         struct aws_s3_paginated_operation *list_parts_operation;
         struct aws_string *list_parts_continuation_token;
 
-        /* Note: total num parts is known only if content-length is known,
-        otherwise it is running total of number of parts read from stream. */
-        uint32_t total_num_parts;
         /* Number of parts we've started work on */
         uint32_t num_parts_sent;
         /* Number of "sent" parts we've finished reading the body for

--- a/include/aws/s3/private/s3_auto_ranged_put.h
+++ b/include/aws/s3/private/s3_auto_ranged_put.h
@@ -31,8 +31,10 @@ struct aws_s3_auto_ranged_put {
     uint64_t content_length;
     bool has_content_length;
 
-    /* Note: total num parts is known only if content-length is known,
-    otherwise it will be 0. */
+    /*
+     * total_num_parts_from_content_length is calculated by content_length / part_size.
+     * It will be 0 if there is no content_length.
+     */
     uint32_t total_num_parts_from_content_length;
 
     /* Only meant for use in the update function, which is never called concurrently. */

--- a/include/aws/s3/private/s3_auto_ranged_put.h
+++ b/include/aws/s3/private/s3_auto_ranged_put.h
@@ -51,11 +51,10 @@ struct aws_s3_auto_ranged_put {
      */
     struct {
         /*
-         * How many parts have been read from input steam.
-         * Since reads are always sequential, this is essentially the number of how many parts were read from start of
-         * stream.
+         * Start index of skipping parts.
+         * This is used to keep track of how many parts have been read from input steam and where to try to start skipping parts from.
          */
-        uint32_t num_parts_read_from_stream;
+        uint32_t part_index_for_skipping;
     } prepare_data;
 
     /* Members to only be used when the mutex in the base type is locked. */

--- a/source/s3_auto_ranged_put.c
+++ b/source/s3_auto_ranged_put.c
@@ -1291,7 +1291,6 @@ static void s_s3_prepare_complete_multipart_upload_on_skipping_done(void *user_d
     struct aws_s3_prepare_complete_multipart_upload_async_ctx *complete_mpu_prep = user_data;
     struct aws_s3_request *request = complete_mpu_prep->request;
     struct aws_s3_meta_request *meta_request = request->meta_request;
-    struct aws_s3_auto_ranged_put *auto_ranged_put = meta_request->impl;
 
     int error_code = aws_future_get_error(complete_mpu_prep->skipping_future);
     if (error_code != AWS_ERROR_SUCCESS) {

--- a/source/s3_auto_ranged_put.c
+++ b/source/s3_auto_ranged_put.c
@@ -515,7 +515,8 @@ static bool s_s3_auto_ranged_put_update(
 
                 // Something went really wrong. we still have parts to send, but have etags for all parts
                 AWS_FATAL_ASSERT(
-                    auto_ranged_put->threaded_update_data.next_part_number <= auto_ranged_put->total_num_parts_from_content_length);
+                    auto_ranged_put->threaded_update_data.next_part_number <=
+                    auto_ranged_put->total_num_parts_from_content_length);
 
                 if (s_should_skip_scheduling_more_parts_based_on_flags(auto_ranged_put, flags)) {
                     goto has_work_remaining;
@@ -568,7 +569,8 @@ static bool s_s3_auto_ranged_put_update(
             /* There is one more request to send after all the parts (the complete-multipart-upload) but it can't be
              * done until all the parts have been completed.*/
             if (auto_ranged_put->has_content_length) {
-                if (auto_ranged_put->synced_data.num_parts_completed != auto_ranged_put->total_num_parts_from_content_length) {
+                if (auto_ranged_put->synced_data.num_parts_completed !=
+                    auto_ranged_put->total_num_parts_from_content_length) {
                     goto has_work_remaining;
                 }
             } else {
@@ -1071,7 +1073,7 @@ struct aws_future *s_s3_prepare_upload_part(struct aws_s3_request *request) {
          * skipped over parts that were already uploaded (in case we're resuming
          * from an upload that had been paused) */
         part_prep->skipping_future = s_skip_parts_from_stream(
-                meta_request, auto_ranged_put->prepare_data.part_index_for_skipping, request->part_number - 1);
+            meta_request, auto_ranged_put->prepare_data.part_index_for_skipping, request->part_number - 1);
         aws_future_register_callback(part_prep->skipping_future, s_s3_prepare_upload_part_on_skipping_done, part_prep);
     } else {
         /* Not the first time preparing request (e.g. retry).
@@ -1245,6 +1247,7 @@ static struct aws_future *s_s3_prepare_complete_multipart_upload(struct aws_s3_r
     aws_s3_meta_request_lock_synced_data(meta_request);
     size_t etag_list_length = aws_array_list_length(&auto_ranged_put->synced_data.etag_list);
     aws_s3_meta_request_unlock_synced_data(meta_request);
+
     /* Note: completeMPU fails if no parts are provided. We could
      * workaround it by uploading an empty part at the cost of
      * complicating flow logic for dealing with noop parts, but that
@@ -1273,7 +1276,9 @@ static struct aws_future *s_s3_prepare_complete_multipart_upload(struct aws_s3_r
         /* Corner case of last part being previously uploaded during resume.
          * Read it from input stream and potentially verify checksum */
         complete_mpu_prep->skipping_future = s_skip_parts_from_stream(
-                meta_request, auto_ranged_put->prepare_data.part_index_for_skipping, auto_ranged_put->total_num_parts_from_content_length);
+            meta_request,
+            auto_ranged_put->prepare_data.part_index_for_skipping,
+            auto_ranged_put->total_num_parts_from_content_length);
 
         aws_future_register_callback(
             complete_mpu_prep->skipping_future,

--- a/source/s3_auto_ranged_put.c
+++ b/source/s3_auto_ranged_put.c
@@ -1242,6 +1242,9 @@ static struct aws_future *s_s3_prepare_complete_multipart_upload(struct aws_s3_r
 
     struct aws_future *message_future = aws_future_new(allocator, AWS_FUTURE_POINTER);
 
+    aws_s3_meta_request_lock_synced_data(meta_request);
+    size_t etag_list_length = aws_array_list_length(&auto_ranged_put->synced_data.etag_list);
+    aws_s3_meta_request_unlock_synced_data(meta_request);
     /* Note: completeMPU fails if no parts are provided. We could
      * workaround it by uploading an empty part at the cost of
      * complicating flow logic for dealing with noop parts, but that
@@ -1249,7 +1252,7 @@ static struct aws_future *s_s3_prepare_complete_multipart_upload(struct aws_s3_r
      * Pre-buffering parts to determine whether mpu is needed will
      * resolve this issue.
      */
-    if (!auto_ranged_put->has_content_length && auto_ranged_put->prepare_data.part_index_for_skipping == 0) {
+    if (!auto_ranged_put->has_content_length && etag_list_length == 0) {
         AWS_LOGF_ERROR(
             AWS_LS_S3_META_REQUEST,
             "id=%p 0 byte meta requests without Content-Length header are currently not supported. Set "

--- a/source/s3_auto_ranged_put.c
+++ b/source/s3_auto_ranged_put.c
@@ -1299,12 +1299,6 @@ static void s_s3_prepare_complete_multipart_upload_on_skipping_done(void *user_d
         return;
     }
 
-    /* Skipping was successful */
-    aws_s3_meta_request_lock_synced_data(meta_request);
-    auto_ranged_put->prepare_data.num_parts_read_from_stream =
-        (uint32_t)aws_array_list_length(&auto_ranged_put->synced_data.etag_list);
-    aws_s3_meta_request_unlock_synced_data(meta_request);
-
     aws_byte_buf_init(
         &request->request_body, meta_request->allocator, s_complete_multipart_upload_init_body_size_bytes);
 

--- a/source/s3_auto_ranged_put.c
+++ b/source/s3_auto_ranged_put.c
@@ -1302,7 +1302,7 @@ static void s_s3_prepare_complete_multipart_upload_on_skipping_done(void *user_d
     /* Skipping was successful */
     aws_s3_meta_request_lock_synced_data(meta_request);
     auto_ranged_put->prepare_data.num_parts_read_from_stream =
-        aws_array_list_length(&auto_ranged_put->synced_data.etag_list);
+        (uint32_t)aws_array_list_length(&auto_ranged_put->synced_data.etag_list);
     aws_s3_meta_request_unlock_synced_data(meta_request);
 
     aws_byte_buf_init(

--- a/source/s3_auto_ranged_put.c
+++ b/source/s3_auto_ranged_put.c
@@ -1289,6 +1289,8 @@ static struct aws_future *s_s3_prepare_complete_multipart_upload(struct aws_s3_r
 static void s_s3_prepare_complete_multipart_upload_on_skipping_done(void *user_data) {
 
     struct aws_s3_prepare_complete_multipart_upload_async_ctx *complete_mpu_prep = user_data;
+    struct aws_s3_request *request = complete_mpu_prep->request;
+    struct aws_s3_meta_request *meta_request = request->meta_request;
 
     int error_code = aws_future_get_error(complete_mpu_prep->skipping_future);
     if (error_code != AWS_ERROR_SUCCESS) {

--- a/tests/s3_cancel_tests.c
+++ b/tests/s3_cancel_tests.c
@@ -65,8 +65,7 @@ static bool s_s3_meta_request_update_cancel_test(
             block_update = !call_cancel && auto_ranged_put->synced_data.num_parts_sent == 1;
             break;
         case S3_UPDATE_CANCEL_TYPE_MPU_ALL_PARTS_COMPLETED:
-            call_cancel =
-                auto_ranged_put->synced_data.num_parts_completed == auto_ranged_put->synced_data.total_num_parts;
+            call_cancel = auto_ranged_put->synced_data.num_parts_completed == auto_ranged_put->total_num_parts;
             break;
 
         case S3_UPDATE_CANCEL_TYPE_NUM_MPU_CANCEL_TYPES:

--- a/tests/s3_cancel_tests.c
+++ b/tests/s3_cancel_tests.c
@@ -65,7 +65,7 @@ static bool s_s3_meta_request_update_cancel_test(
             block_update = !call_cancel && auto_ranged_put->synced_data.num_parts_sent == 1;
             break;
         case S3_UPDATE_CANCEL_TYPE_MPU_ALL_PARTS_COMPLETED:
-            call_cancel = auto_ranged_put->synced_data.num_parts_completed == auto_ranged_put->total_num_parts;
+            call_cancel = auto_ranged_put->synced_data.num_parts_completed == auto_ranged_put->total_num_parts_from_content_length;
             break;
 
         case S3_UPDATE_CANCEL_TYPE_NUM_MPU_CANCEL_TYPES:

--- a/tests/s3_cancel_tests.c
+++ b/tests/s3_cancel_tests.c
@@ -65,7 +65,8 @@ static bool s_s3_meta_request_update_cancel_test(
             block_update = !call_cancel && auto_ranged_put->synced_data.num_parts_sent == 1;
             break;
         case S3_UPDATE_CANCEL_TYPE_MPU_ALL_PARTS_COMPLETED:
-            call_cancel = auto_ranged_put->synced_data.num_parts_completed == auto_ranged_put->total_num_parts_from_content_length;
+            call_cancel = auto_ranged_put->synced_data.num_parts_completed ==
+                          auto_ranged_put->total_num_parts_from_content_length;
             break;
 
         case S3_UPDATE_CANCEL_TYPE_NUM_MPU_CANCEL_TYPES:


### PR DESCRIPTION
*Description of changes:*
- Make total_num_parts non async. total_num_parts is now defined at the time of creation and never changes. For no content_length case it will be zero.
- Replace some hacks around running total_num_parts with different hacks that don't rely on total_num_parts. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
