### PR TITLE
Adapt to aws_future and aws_async_input_stream API changes

### DIFF
--- a/include/aws/s3/private/s3_meta_request_impl.h
+++ b/include/aws/s3/private/s3_meta_request_impl.h
@@ -8,7 +8,6 @@
 
 #include <aws/auth/signing.h>
 #include <aws/common/atomics.h>
-#include <aws/common/future.h>
 #include <aws/common/linked_list.h>
 #include <aws/common/mutex.h>
 #include <aws/common/ref_count.h>
@@ -50,7 +49,7 @@ struct aws_s3_prepare_request_payload {
     aws_s3_meta_request_prepare_request_callback_fn *callback;
     void *user_data;
     struct aws_task task;
-    struct aws_future *preparation_future; /* aws_future<void> this operation is waiting on */
+    struct aws_future_void *preparation_future; /* Future this operation is waiting on */
 };
 
 struct aws_s3_meta_request_vtable {
@@ -69,8 +68,8 @@ struct aws_s3_meta_request_vtable {
 
     /* Given a request, asynchronously prepare it for sending
      * (creating the correct HTTP message, reading from a stream (if necessary), computing hashes, etc.).
-     * Returns aws_future<void>, which may complete on any thread (and may complete synchronously). */
-    struct aws_future *(*prepare_request)(struct aws_s3_request *request);
+     * Returns a future, which may complete on any thread (and may complete synchronously). */
+    struct aws_future_void *(*prepare_request)(struct aws_s3_request *request);
 
     void (*init_signing_date_time)(struct aws_s3_meta_request *meta_request, struct aws_date_time *date_time);
 
@@ -114,7 +113,7 @@ struct aws_s3_meta_request {
     struct aws_http_message *initial_request_message;
 
     /* Async stream for meta request's body */
-    struct aws_async_stream *send_async_body;
+    struct aws_async_input_stream *send_async_body;
 
     /* Part size to use for uploads and downloads.  Passed down by the creating client. */
     const size_t part_size;
@@ -308,11 +307,13 @@ void aws_s3_meta_request_stream_response_body_synced(
  * as reading from the stream could cause user code to call back into aws-c-s3.
  * This will fill the buffer to capacity, unless end of stream is reached.
  * It may read from the underlying stream multiple times, if that's what it takes to fill the buffer.
- * Returns an aws_future<bool> indicating whether end of stream was reached.
+ * Returns a future whose result bool indicates whether end of stream was reached.
  * This future may complete on any thread, and may complete synchronously.
  */
 AWS_S3_API
-struct aws_future *aws_s3_meta_request_read_body(struct aws_s3_meta_request *meta_request, struct aws_byte_buf *buffer);
+struct aws_future_bool *aws_s3_meta_request_read_body(
+    struct aws_s3_meta_request *meta_request,
+    struct aws_byte_buf *buffer);
 
 bool aws_s3_meta_request_body_has_no_more_data(const struct aws_s3_meta_request *meta_request);
 

--- a/include/aws/s3/private/s3_request_messages.h
+++ b/include/aws/s3/private/s3_request_messages.h
@@ -57,11 +57,11 @@ struct aws_input_stream *aws_s3_message_util_assign_body(
 
 /* Given all possible ways to send a request body, always return an async-stream.
  * Returns NULL on failure */
-struct aws_async_stream *aws_s3_message_util_acquire_async_body_stream(
+struct aws_async_input_stream *aws_s3_message_util_acquire_async_body_stream(
     struct aws_allocator *allocator,
     struct aws_http_message *message,
     struct aws_byte_cursor send_filepath,
-    struct aws_async_stream *send_async_stream);
+    struct aws_async_input_stream *send_async_stream);
 
 /* Return true if checksum headers has been set. */
 AWS_S3_API

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -408,7 +408,7 @@ struct aws_s3_meta_request_options {
      * Use this when outgoing data will be produced in asynchronous chunks.
      * Do not set if the body is being passed by other means (see note above).
      */
-    struct aws_async_stream *send_async_stream;
+    struct aws_async_input_stream *send_async_stream;
 
     /**
      * Optional.

--- a/source/s3_auto_ranged_get.c
+++ b/source/s3_auto_ranged_get.c
@@ -22,7 +22,7 @@ static bool s_s3_auto_ranged_get_update(
     uint32_t flags,
     struct aws_s3_request **out_request);
 
-static struct aws_future *s_s3_auto_ranged_get_prepare_request(struct aws_s3_request *request);
+static struct aws_future_void *s_s3_auto_ranged_get_prepare_request(struct aws_s3_request *request);
 
 static void s_s3_auto_ranged_get_request_finished(
     struct aws_s3_meta_request *meta_request,
@@ -331,7 +331,7 @@ static bool s_s3_auto_ranged_get_update(
 
 /* Given a request, prepare it for sending based on its description.
  * Currently, this is actually synchronous. */
-static struct aws_future *s_s3_auto_ranged_get_prepare_request(struct aws_s3_request *request) {
+static struct aws_future_void *s_s3_auto_ranged_get_prepare_request(struct aws_s3_request *request) {
     AWS_PRECONDITION(request);
     struct aws_s3_meta_request *meta_request = request->meta_request;
 
@@ -402,11 +402,11 @@ static struct aws_future *s_s3_auto_ranged_get_prepare_request(struct aws_s3_req
     success = true;
 
 finish:;
-    struct aws_future *future = aws_future_new(meta_request->allocator, AWS_FUTURE_VALUELESS);
+    struct aws_future_void *future = aws_future_void_new(meta_request->allocator);
     if (success) {
-        aws_future_set_valueless(future);
+        aws_future_void_set_result(future);
     } else {
-        aws_future_set_error(future, aws_last_error_or_unknown());
+        aws_future_void_set_error(future, aws_last_error_or_unknown());
     }
     return future;
 }

--- a/source/s3_auto_ranged_put.c
+++ b/source/s3_auto_ranged_put.c
@@ -1410,6 +1410,7 @@ static void s_s3_auto_ranged_put_prepare_request_finish(void *user_data) {
     /* Success! Apply aws_http_message to aws_s3_request */
     struct aws_http_message *message = aws_future_http_message_get_result_by_move(request_prep->message_future);
     aws_s3_request_setup_send_data(request, message);
+    aws_http_message_release(message);
 
     AWS_LOGF_DEBUG(
         AWS_LS_S3_META_REQUEST,

--- a/source/s3_copy_object.c
+++ b/source/s3_copy_object.c
@@ -7,7 +7,6 @@
 #include "aws/s3/private/s3_request_messages.h"
 #include "aws/s3/private/s3_util.h"
 #include <aws/common/string.h>
-#include <aws/io/stream.h>
 
 /* Objects with size smaller than the constant below are bypassed as S3 CopyObject instead of multipart copy */
 static const size_t s_multipart_copy_minimum_object_size = 1L * 1024L * 1024L * 1024L;
@@ -30,7 +29,7 @@ static bool s_s3_copy_object_update(
     uint32_t flags,
     struct aws_s3_request **out_request);
 
-static struct aws_future *s_s3_copy_object_prepare_request(struct aws_s3_request *request);
+static struct aws_future_void *s_s3_copy_object_prepare_request(struct aws_s3_request *request);
 
 static void s_s3_copy_object_request_finished(
     struct aws_s3_meta_request *meta_request,
@@ -333,7 +332,7 @@ no_work_remaining:
 }
 
 /* Given a request, prepare it for sending based on its description. */
-static struct aws_future *s_s3_copy_object_prepare_request(struct aws_s3_request *request) {
+static struct aws_future_void *s_s3_copy_object_prepare_request(struct aws_s3_request *request) {
     struct aws_s3_meta_request *meta_request = request->meta_request;
     AWS_PRECONDITION(meta_request);
 
@@ -518,11 +517,11 @@ static struct aws_future *s_s3_copy_object_prepare_request(struct aws_s3_request
     success = true;
 
 finish:;
-    struct aws_future *future = aws_future_new(meta_request->allocator, AWS_FUTURE_VALUELESS);
+    struct aws_future_void *future = aws_future_void_new(meta_request->allocator);
     if (success) {
-        aws_future_set_valueless(future);
+        aws_future_void_set_result(future);
     } else {
-        aws_future_set_error(future, aws_last_error_or_unknown());
+        aws_future_void_set_error(future, aws_last_error_or_unknown());
     }
     return future;
 }

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -13,10 +13,10 @@
 #include <aws/auth/signing.h>
 #include <aws/auth/signing_config.h>
 #include <aws/auth/signing_result.h>
-#include <aws/common/async_stream.h>
 #include <aws/common/encoding.h>
 #include <aws/common/string.h>
 #include <aws/common/system_info.h>
+#include <aws/io/async_stream.h>
 #include <aws/io/event_loop.h>
 #include <aws/io/retry_strategy.h>
 #include <aws/io/socket.h>
@@ -234,7 +234,7 @@ int aws_s3_meta_request_init_base(
     meta_request->initial_request_message = aws_http_message_acquire(options->message);
 
     /* There are several ways for the user to pass in the request's body.
-     * If something besides an aws_async_stream was passed in, create an
+     * If something besides an aws_async_input_stream was passed in, create an
      * async wrapper around it */
     meta_request->send_async_body = aws_s3_message_util_acquire_async_body_stream(
         allocator, meta_request->initial_request_message, options->send_filepath, options->send_async_stream);
@@ -425,7 +425,7 @@ static void s_s3_meta_request_destroy(void *user_data) {
     AWS_LOGF_DEBUG(AWS_LS_S3_META_REQUEST, "id=%p Cleaning up meta request", (void *)meta_request);
 
     /* Clean up our initial http message */
-    meta_request->send_async_body = aws_async_stream_release(meta_request->send_async_body);
+    meta_request->send_async_body = aws_async_input_stream_release(meta_request->send_async_body);
     meta_request->initial_request_message = aws_http_message_release(meta_request->initial_request_message);
 
     void *meta_request_user_data = meta_request->user_data;
@@ -539,7 +539,7 @@ static void s_s3_prepare_request_payload_callback_and_destroy(
         payload->callback(meta_request, payload->request, error_code, payload->user_data);
     }
 
-    aws_future_release(payload->preparation_future);
+    aws_future_void_release(payload->preparation_future);
     aws_mem_release(payload->allocator, payload);
 }
 
@@ -618,7 +618,7 @@ static void s_s3_meta_request_prepare_request_task(struct aws_task *task, void *
     /* Kick off the async vtable->prepare_request()
      * Each subclass has its own implementation of this. */
     payload->preparation_future = vtable->prepare_request(request);
-    aws_future_register_callback(payload->preparation_future, s_s3_meta_request_on_request_prepared, payload);
+    aws_future_void_register_callback(payload->preparation_future, s_s3_meta_request_on_request_prepared, payload);
     return;
 }
 
@@ -628,7 +628,7 @@ static void s_s3_meta_request_on_request_prepared(void *user_data) {
     struct aws_s3_request *request = payload->request;
     struct aws_s3_meta_request *meta_request = request->meta_request;
 
-    int error_code = aws_future_get_error(payload->preparation_future);
+    int error_code = aws_future_void_get_error(payload->preparation_future);
     if (error_code) {
         s_s3_prepare_request_payload_callback_and_destroy(payload, error_code);
         return;
@@ -1565,7 +1565,7 @@ void aws_s3_meta_request_finish_default(struct aws_s3_meta_request *meta_request
     /* As the meta request has been finished with any HTTP message, we can safely release the http message that hold. So
      * that, the downstream high level language doesn't need to wait for shutdown to clean related resource (eg: input
      * stream) */
-    meta_request->send_async_body = aws_async_stream_release(meta_request->send_async_body);
+    meta_request->send_async_body = aws_async_input_stream_release(meta_request->send_async_body);
     meta_request->initial_request_message = aws_http_message_release(meta_request->initial_request_message);
 
     if (meta_request->finish_callback != NULL) {
@@ -1580,14 +1580,14 @@ void aws_s3_meta_request_finish_default(struct aws_s3_meta_request *meta_request
     meta_request->io_event_loop = NULL;
 }
 
-struct aws_future *aws_s3_meta_request_read_body(
+struct aws_future_bool *aws_s3_meta_request_read_body(
     struct aws_s3_meta_request *meta_request,
     struct aws_byte_buf *buffer) {
 
     AWS_PRECONDITION(meta_request);
     AWS_PRECONDITION(buffer);
 
-    return aws_async_stream_read_to_fill(meta_request->send_async_body, buffer);
+    return aws_async_input_stream_read_to_fill(meta_request->send_async_body, buffer);
 }
 
 bool aws_s3_meta_request_body_has_no_more_data(const struct aws_s3_meta_request *meta_request) {

--- a/tests/s3_retry_tests.c
+++ b/tests/s3_retry_tests.c
@@ -123,10 +123,10 @@ struct s3_fail_prepare_test_data {
     uint32_t num_requests_being_prepared_is_correct : 1;
 };
 
-static struct aws_future *s_s3_fail_prepare_request(struct aws_s3_request *request) {
+static struct aws_future_void *s_s3_fail_prepare_request(struct aws_s3_request *request) {
     AWS_ASSERT(request != NULL);
-    struct aws_future *future = aws_future_new(request->allocator, AWS_FUTURE_VALUELESS);
-    aws_future_set_error(future, AWS_ERROR_UNKNOWN);
+    struct aws_future_void *future = aws_future_void_new(request->allocator);
+    aws_future_void_set_error(future, AWS_ERROR_UNKNOWN);
     return future;
 }
 
@@ -280,13 +280,13 @@ static int s_test_s3_meta_request_sign_request_fail(struct aws_allocator *alloca
 struct s3_meta_request_prepare_request_fail_first_async_ctx {
     struct aws_allocator *allocator;
     struct aws_s3_request *request;
-    struct aws_future *original_future; /* original future that we're intercepting and patching */
-    struct aws_future *my_future;       /* patched future to set when this operation completes */
+    struct aws_future_void *original_future; /* original future that we're intercepting and patching */
+    struct aws_future_void *my_future;       /* patched future to set when this operation completes */
 };
 
 static void s_s3_meta_request_prepare_request_fail_first_on_original_done(void *user_data);
 
-static struct aws_future *s_s3_meta_request_prepare_request_fail_first(struct aws_s3_request *request) {
+static struct aws_future_void *s_s3_meta_request_prepare_request_fail_first(struct aws_s3_request *request) {
 
     struct aws_s3_meta_request *meta_request = request->meta_request;
     AWS_ASSERT(meta_request);
@@ -297,20 +297,20 @@ static struct aws_future *s_s3_meta_request_prepare_request_fail_first(struct aw
     struct aws_s3_tester *tester = client->shutdown_callback_user_data;
     AWS_ASSERT(tester != NULL);
 
-    struct aws_future *patched_future = aws_future_new(request->allocator, AWS_FUTURE_VALUELESS);
+    struct aws_future_void *patched_future = aws_future_void_new(request->allocator);
 
     struct s3_meta_request_prepare_request_fail_first_async_ctx *patched_prep =
         aws_mem_calloc(request->allocator, 1, sizeof(struct s3_meta_request_prepare_request_fail_first_async_ctx));
 
     patched_prep->allocator = request->allocator;
-    patched_prep->my_future = aws_future_acquire(patched_future);
+    patched_prep->my_future = aws_future_void_acquire(patched_future);
     patched_prep->request = request;
 
     struct aws_s3_meta_request_vtable *original_meta_request_vtable =
         aws_s3_tester_get_meta_request_vtable_patch(tester, 0)->original_vtable;
 
     patched_prep->original_future = original_meta_request_vtable->prepare_request(request);
-    aws_future_register_callback(
+    aws_future_void_register_callback(
         patched_prep->original_future, s_s3_meta_request_prepare_request_fail_first_on_original_done, patched_prep);
 
     return patched_future;
@@ -322,9 +322,9 @@ static void s_s3_meta_request_prepare_request_fail_first_on_original_done(void *
     struct aws_s3_request *request = patched_prep->request;
     struct aws_s3_tester *tester = request->meta_request->client->shutdown_callback_user_data;
 
-    int error_code = aws_future_get_error(patched_prep->original_future);
+    int error_code = aws_future_void_get_error(patched_prep->original_future);
     if (error_code != AWS_ERROR_SUCCESS) {
-        aws_future_set_error(patched_prep->my_future, error_code);
+        aws_future_void_set_error(patched_prep->my_future, error_code);
         goto finish;
     }
 
@@ -338,10 +338,10 @@ static void s_s3_meta_request_prepare_request_fail_first_on_original_done(void *
         (void)set_request_path_result;
     }
 
-    aws_future_set_valueless(patched_prep->my_future);
+    aws_future_void_set_result(patched_prep->my_future);
 finish:
-    aws_future_release(patched_prep->original_future);
-    aws_future_release(patched_prep->my_future);
+    aws_future_void_release(patched_prep->original_future);
+    aws_future_void_release(patched_prep->my_future);
     aws_mem_release(patched_prep->allocator, patched_prep);
 }
 

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -793,9 +793,9 @@ static void s_s3_meta_request_schedule_prepare_request_empty(
     (void)user_data;
 }
 
-static struct aws_future *s_s3_meta_request_prepare_request_async_empty(struct aws_s3_request *request) {
-    struct aws_future *future = aws_future_new(request->allocator, AWS_FUTURE_VALUELESS);
-    aws_future_set_error(future, AWS_ERROR_UNKNOWN);
+static struct aws_future_void *s_s3_meta_request_prepare_request_async_empty(struct aws_s3_request *request) {
+    struct aws_future_void *future = aws_future_void_new(request->allocator);
+    aws_future_void_set_error(future, AWS_ERROR_UNKNOWN);
     return future;
 }
 


### PR DESCRIPTION
- aws_future is now 100% type-safe
- renamed ~aws_async_stream~ -> `aws_async_input_stream`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
