### PR TITLE
Move endpoint resolver private header to .c file

### DIFF
--- a/include/aws/s3/s3_endpoint_resolver.h
+++ b/include/aws/s3/s3_endpoint_resolver.h
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-#include <aws/s3/private/s3_endpoint_resolver.h>
 #include <aws/s3/s3.h>
 AWS_PUSH_SANE_WARNING_LEVEL
 

--- a/scripts/update_s3_endpoint_resolver_artifacts.py
+++ b/scripts/update_s3_endpoint_resolver_artifacts.py
@@ -31,9 +31,9 @@ def get_header():
  * Copyright Amazon.com, Inc. or its affiliates.
  * All Rights Reserved. SPDX-License-Identifier: Apache-2.0.
  */
-
-#include <aws/s3/s3_endpoint_resolver.h>
+ 
 #include "aws/s3/private/s3_endpoint_resolver.h"
+#include <aws/s3/s3_endpoint_resolver.h>
 
 /**
  * This file is generated using scripts/update_s3_endpoint_resolver_artifacts.py.

--- a/scripts/update_s3_endpoint_resolver_artifacts.py
+++ b/scripts/update_s3_endpoint_resolver_artifacts.py
@@ -33,6 +33,7 @@ def get_header():
  */
 
 #include <aws/s3/s3_endpoint_resolver.h>
+#include "aws/s3/private/s3_endpoint_resolver.h"
 
 /**
  * This file is generated using scripts/update_s3_endpoint_resolver_artifacts.py.

--- a/scripts/update_s3_endpoint_resolver_artifacts.py
+++ b/scripts/update_s3_endpoint_resolver_artifacts.py
@@ -31,7 +31,6 @@ def get_header():
  * Copyright Amazon.com, Inc. or its affiliates.
  * All Rights Reserved. SPDX-License-Identifier: Apache-2.0.
  */
- 
 #include "aws/s3/private/s3_endpoint_resolver.h"
 #include <aws/s3/s3_endpoint_resolver.h>
 

--- a/source/s3_endpoint_resolver/aws_s3_endpoint_resolver_partition.c
+++ b/source/s3_endpoint_resolver/aws_s3_endpoint_resolver_partition.c
@@ -4,6 +4,7 @@
  */
 
 #include <aws/s3/s3_endpoint_resolver.h>
+#include "aws/s3/private/s3_endpoint_resolver.h"
 
 /**
  * This file is generated using scripts/update_s3_endpoint_resolver_artifacts.py.

--- a/source/s3_endpoint_resolver/aws_s3_endpoint_resolver_partition.c
+++ b/source/s3_endpoint_resolver/aws_s3_endpoint_resolver_partition.c
@@ -2,7 +2,6 @@
  * Copyright Amazon.com, Inc. or its affiliates.
  * All Rights Reserved. SPDX-License-Identifier: Apache-2.0.
  */
- 
 #include "aws/s3/private/s3_endpoint_resolver.h"
 #include <aws/s3/s3_endpoint_resolver.h>
 

--- a/source/s3_endpoint_resolver/aws_s3_endpoint_resolver_partition.c
+++ b/source/s3_endpoint_resolver/aws_s3_endpoint_resolver_partition.c
@@ -2,9 +2,9 @@
  * Copyright Amazon.com, Inc. or its affiliates.
  * All Rights Reserved. SPDX-License-Identifier: Apache-2.0.
  */
-
-#include <aws/s3/s3_endpoint_resolver.h>
+ 
 #include "aws/s3/private/s3_endpoint_resolver.h"
+#include <aws/s3/s3_endpoint_resolver.h>
 
 /**
  * This file is generated using scripts/update_s3_endpoint_resolver_artifacts.py.

--- a/source/s3_endpoint_resolver/aws_s3_endpoint_rule_set.c
+++ b/source/s3_endpoint_resolver/aws_s3_endpoint_rule_set.c
@@ -4,6 +4,7 @@
  */
 
 #include <aws/s3/s3_endpoint_resolver.h>
+#include "aws/s3/private/s3_endpoint_resolver.h"
 
 /**
  * This file is generated using scripts/update_s3_endpoint_resolver_artifacts.py.

--- a/source/s3_endpoint_resolver/aws_s3_endpoint_rule_set.c
+++ b/source/s3_endpoint_resolver/aws_s3_endpoint_rule_set.c
@@ -2,7 +2,6 @@
  * Copyright Amazon.com, Inc. or its affiliates.
  * All Rights Reserved. SPDX-License-Identifier: Apache-2.0.
  */
- 
 #include "aws/s3/private/s3_endpoint_resolver.h"
 #include <aws/s3/s3_endpoint_resolver.h>
 

--- a/source/s3_endpoint_resolver/aws_s3_endpoint_rule_set.c
+++ b/source/s3_endpoint_resolver/aws_s3_endpoint_rule_set.c
@@ -2,9 +2,9 @@
  * Copyright Amazon.com, Inc. or its affiliates.
  * All Rights Reserved. SPDX-License-Identifier: Apache-2.0.
  */
-
-#include <aws/s3/s3_endpoint_resolver.h>
+ 
 #include "aws/s3/private/s3_endpoint_resolver.h"
+#include <aws/s3/s3_endpoint_resolver.h>
 
 /**
  * This file is generated using scripts/update_s3_endpoint_resolver_artifacts.py.

--- a/source/s3_endpoint_resolver/s3_endpoint_resolver.c
+++ b/source/s3_endpoint_resolver/s3_endpoint_resolver.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#include "aws/s3/private/s3_endpoint_resolver.h"
 #include <aws/s3/s3_endpoint_resolver.h>
 #include <aws/sdkutils/endpoints_rule_engine.h>
 #include <aws/sdkutils/partitions.h>


### PR DESCRIPTION
*Description of changes:*
- The private header is included in a public header which will not work for the consumer of this application. Move it to .c file for correct linker resolution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
