### PR TITLE
Progress callbacks fire for all meta-request types

### DIFF
--- a/include/aws/s3/private/s3_auto_ranged_get.h
+++ b/include/aws/s3/private/s3_auto_ranged_get.h
@@ -25,7 +25,9 @@ struct aws_s3_auto_ranged_get {
         uint64_t object_range_start;
 
         /* The last byte of the data that will be retrieved from the object.
-         * (ignore this if object_range_empty) */
+         * (ignore this if object_range_empty)
+         * Note this is inclusive: https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
+         * So if begin=0 and end=0 then 1 byte is being downloaded. */
         uint64_t object_range_end;
 
         /* The total number of parts that are being used in downloading the object range. Note that "part" here

--- a/include/aws/s3/private/s3_meta_request_impl.h
+++ b/include/aws/s3/private/s3_meta_request_impl.h
@@ -54,6 +54,25 @@ struct aws_s3_prepare_request_payload {
     void *user_data;
 };
 
+/* An event to be delivered on the meta-request's io_event_loop thread. */
+struct aws_s3_meta_request_event {
+    enum aws_s3_meta_request_event_type {
+        AWS_S3_META_REQUEST_EVENT_RESPONSE_BODY, /* body_callback */
+        AWS_S3_META_REQUEST_EVENT_PROGRESS,      /* progress_callback */
+        /* TODO: AWS_S3_META_REQUEST_EVENT_TELEMETRY */
+    } type;
+
+    union {
+        struct {
+            struct aws_s3_request *request;
+        } response_body;
+
+        struct {
+            struct aws_s3_meta_request_progress info;
+        } progress;
+    } u;
+};
+
 struct aws_s3_meta_request_vtable {
     /* Update the meta request.  out_request is required to be non-null. Returns true if there is any work in
      * progress, false if there is not. */
@@ -179,11 +198,19 @@ struct aws_s3_meta_request {
          * failed.)*/
         uint32_t num_parts_delivery_completed;
 
-        /* Number of parts that have been successfully delivered to the caller. */
-        uint32_t num_parts_delivery_succeeded;
+        /* Task for delivering events on the meta-request's io_event_loop thread.
+         * We do this to ensure a meta-request's callbacks are fired sequentially and non-overlapping.
+         * If `event_delivery_array` has items in it, then this task is scheduled.
+         * If `event_delivery_active` is true, then this task is actively running.
+         * Delivery is not 100% complete until `event_delivery_array` is empty AND `event_delivery_active` is false
+         * (use aws_s3_meta_request_are_events_out_for_delivery_synced()  to check) */
+        struct aws_task event_delivery_task;
 
-        /* Number of parts that have failed while trying to be delivered to the caller. */
-        uint32_t num_parts_delivery_failed;
+        /* Array of `struct aws_s3_meta_request_event` to deliver when the `event_delivery_task` runs. */
+        struct aws_array_list event_delivery_array;
+
+        /* When true, events are actively being delivered to the user. */
+        bool event_delivery_active;
 
         /* The end finish result of the meta request. */
         struct aws_s3_meta_request_result finish_result;
@@ -204,6 +231,14 @@ struct aws_s3_meta_request {
         bool scheduled;
 
     } client_process_work_threaded_data;
+
+    /* Anything in this structure should only ever be accessed by the meta-request from its io_event_loop thread. */
+    struct {
+        /* When delivering events, we swap contents with `synced_data.event_delivery_array`.
+         * This is an optimization, we could have just copied the array when the task runs,
+         * but swapping two array-lists back and forth avoids an allocation. */
+        struct aws_array_list event_delivery_array;
+    } io_threaded_data;
 
     const bool should_compute_content_md5;
 
@@ -315,6 +350,19 @@ AWS_S3_API
 void aws_s3_meta_request_stream_response_body_synced(
     struct aws_s3_meta_request *meta_request,
     struct aws_s3_request *request);
+
+/* Add an event for delivery on the meta-request's io_event_loop thread.
+ * These events usually correspond to callbacks that must fire sequentially and non-overlapping,
+ * such as delivery of a part's response body. */
+AWS_S3_API
+void aws_s3_meta_request_add_event_for_delivery_synced(
+    struct aws_s3_meta_request *meta_request,
+    const struct aws_s3_meta_request_event *event);
+
+/* Returns whether any events are out for delivery.
+ * The meta-request's finish callback must not be invoked until this returns false. */
+AWS_S3_API
+bool aws_s3_meta_request_are_events_out_for_delivery_synced(struct aws_s3_meta_request *meta_request);
 
 /* Asynchronously read from the meta request's input stream. Should always be done outside of any mutex,
  * as reading from the stream could cause user code to call back into aws-c-s3.

--- a/include/aws/s3/private/s3_meta_request_impl.h
+++ b/include/aws/s3/private/s3_meta_request_impl.h
@@ -354,14 +354,12 @@ void aws_s3_meta_request_stream_response_body_synced(
 /* Add an event for delivery on the meta-request's io_event_loop thread.
  * These events usually correspond to callbacks that must fire sequentially and non-overlapping,
  * such as delivery of a part's response body. */
-AWS_S3_API
 void aws_s3_meta_request_add_event_for_delivery_synced(
     struct aws_s3_meta_request *meta_request,
     const struct aws_s3_meta_request_event *event);
 
 /* Returns whether any events are out for delivery.
  * The meta-request's finish callback must not be invoked until this returns false. */
-AWS_S3_API
 bool aws_s3_meta_request_are_events_out_for_delivery_synced(struct aws_s3_meta_request *meta_request);
 
 /* Asynchronously read from the meta request's input stream. Should always be done outside of any mutex,

--- a/include/aws/s3/private/s3_meta_request_impl.h
+++ b/include/aws/s3/private/s3_meta_request_impl.h
@@ -63,10 +63,12 @@ struct aws_s3_meta_request_event {
     } type;
 
     union {
+        /* data for AWS_S3_META_REQUEST_EVENT_RESPONSE_BODY */
         struct {
-            struct aws_s3_request *request;
+            struct aws_s3_request *completed_request;
         } response_body;
 
+        /* data for AWS_S3_META_REQUEST_EVENT_PROGRESS */
         struct {
             struct aws_s3_meta_request_progress info;
         } progress;

--- a/include/aws/s3/private/s3_request.h
+++ b/include/aws/s3/private/s3_request.h
@@ -224,10 +224,10 @@ AWS_S3_API
 void aws_s3_request_clean_up_send_data(struct aws_s3_request *request);
 
 AWS_S3_API
-void aws_s3_request_acquire(struct aws_s3_request *request);
+struct aws_s3_request *aws_s3_request_acquire(struct aws_s3_request *request);
 
 AWS_S3_API
-void aws_s3_request_release(struct aws_s3_request *request);
+struct aws_s3_request *aws_s3_request_release(struct aws_s3_request *request);
 
 AWS_S3_API
 struct aws_s3_request_metrics *aws_s3_request_metrics_new(

--- a/include/aws/s3/private/s3_util.h
+++ b/include/aws/s3/private/s3_util.h
@@ -24,7 +24,7 @@
 #endif
 #define KB_TO_BYTES(kb) ((kb)*1024)
 #define MB_TO_BYTES(mb) ((mb)*1024 * 1024)
-#define GB_TO_BYTES(gb) ((gb)*1024 * 1024 * 1024)
+#define GB_TO_BYTES(gb) ((gb)*1024 * 1024 * 1024ULL)
 
 #define MS_TO_NS(ms) ((uint64_t)(ms)*1000000)
 #define SEC_TO_NS(ms) ((uint64_t)(ms)*1000000000)

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -177,7 +177,11 @@ struct aws_s3_meta_request_progress {
 };
 
 /**
- * Invoked to report progress of multi-part upload and copy object requests.
+ * Invoked to report progress of a meta-request.
+ * For PutObject, progress refers to bytes uploaded.
+ * For CopyObject, progress refers to bytes copied.
+ * For GetObject, progress refers to bytes downloaded.
+ * For anything else, progress refers to response bytes received.
  */
 typedef void(aws_s3_meta_request_progress_fn)(
     struct aws_s3_meta_request *meta_request,
@@ -534,6 +538,7 @@ struct aws_s3_meta_request_options {
 
     /**
      * Invoked to report progress of the meta request execution.
+     * See `aws_s3_meta_request_progress_fn`.
      */
     aws_s3_meta_request_progress_fn *progress_callback;
 

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -181,7 +181,7 @@ struct aws_s3_meta_request_progress {
  * For PutObject, progress refers to bytes uploaded.
  * For CopyObject, progress refers to bytes copied.
  * For GetObject, progress refers to bytes downloaded.
- * For anything else, progress refers to response bytes received.
+ * For anything else, progress refers to response body bytes received.
  */
 typedef void(aws_s3_meta_request_progress_fn)(
     struct aws_s3_meta_request *meta_request,

--- a/source/s3_auto_ranged_get.c
+++ b/source/s3_auto_ranged_get.c
@@ -193,7 +193,7 @@ static bool s_s3_auto_ranged_get_update(
                         AWS_S3_REQUEST_FLAG_RECORD_RESPONSE_HEADERS | AWS_S3_REQUEST_FLAG_PART_SIZE_RESPONSE_BODY);
 
                     request->part_range_start = 0;
-                    request->part_range_end = meta_request->part_size - 1;
+                    request->part_range_end = meta_request->part_size - 1; /* range-end is inclusive */
                     request->discovers_object_size = true;
 
                     ++auto_ranged_get->synced_data.num_parts_requested;
@@ -498,7 +498,7 @@ static int s_discover_object_range_and_content_length(
              * object range and total object size. Otherwise, the size and range should be equal to the
              * total_content_length. */
             if (!auto_ranged_get->initial_message_has_range_header) {
-                object_range_end = total_content_length - 1;
+                object_range_end = total_content_length - 1; /* range-end is inclusive */
             } else if (aws_s3_parse_content_range_response_header(
                            meta_request->allocator,
                            request->send_data.response_headers,
@@ -557,7 +557,7 @@ static int s_discover_object_range_and_content_length(
 
             /* When discovering the object size via first-part, the object range is the entire object. */
             object_range_start = 0;
-            object_range_end = total_content_length - 1;
+            object_range_end = total_content_length - 1; /* range-end is inclusive */
 
             result = AWS_OP_SUCCESS;
             break;
@@ -703,11 +703,13 @@ update_synced_data:
                     if (meta_request->progress_callback != NULL) {
                         struct aws_s3_meta_request_event event = {.type = AWS_S3_META_REQUEST_EVENT_PROGRESS};
                         event.u.progress.info.bytes_transferred = request->send_data.response_body.len;
-                        event.u.progress.info.content_length =
-                            auto_ranged_get->synced_data.object_range_empty
-                                ? 0
-                                : (auto_ranged_get->synced_data.object_range_end + 1 -
-                                   auto_ranged_get->synced_data.object_range_start);
+                        if (auto_ranged_get->synced_data.object_range_empty) {
+                            event.u.progress.info.content_length = 0;
+                        } else {
+                            /* Note that range-end is inclusive */
+                            event.u.progress.info.content_length = auto_ranged_get->synced_data.object_range_end + 1 -
+                                                                   auto_ranged_get->synced_data.object_range_start;
+                        }
                         aws_s3_meta_request_add_event_for_delivery_synced(meta_request, &event);
                     }
 

--- a/source/s3_auto_ranged_put.c
+++ b/source/s3_auto_ranged_put.c
@@ -693,6 +693,10 @@ static bool s_s3_auto_ranged_put_update(
         work_remaining = true;
 
     no_work_remaining:
+        /* If some events are still being delivered to caller, then wait for those to finish */
+        if (!work_remaining && aws_s3_meta_request_are_events_out_for_delivery_synced(meta_request)) {
+            work_remaining = true;
+        }
 
         if (!work_remaining) {
             aws_s3_meta_request_set_success_synced(meta_request, AWS_S3_RESPONSE_STATUS_SUCCESS);
@@ -1598,6 +1602,8 @@ static void s_s3_auto_ranged_put_request_finished(
                             AWS_LS_S3_META_REQUEST, "id=%p Failed to parse list parts response.", (void *)meta_request);
                         error_code = AWS_ERROR_S3_LIST_PARTS_PARSE_FAILED;
                     } else if (!has_more_results) {
+                        uint64_t bytes_previously_uploaded = 0;
+
                         for (size_t part_index = 0;
                              part_index < aws_array_list_length(&auto_ranged_put->synced_data.part_list);
                              part_index++) {
@@ -1607,6 +1613,8 @@ static void s_s3_auto_ranged_put_request_finished(
                                 /* Update the number of parts sent/completed previously */
                                 ++auto_ranged_put->synced_data.num_parts_started;
                                 ++auto_ranged_put->synced_data.num_parts_completed;
+
+                                bytes_previously_uploaded += part->size;
                             }
                         }
 
@@ -1616,6 +1624,14 @@ static void s_s3_auto_ranged_put_request_finished(
                             (void *)meta_request,
                             auto_ranged_put->synced_data.num_parts_completed,
                             auto_ranged_put->total_num_parts_from_content_length);
+
+                        /* Deliver an initial progress_callback to report all previously uploaded parts. */
+                        if (meta_request->progress_callback != NULL && bytes_previously_uploaded > 0) {
+                            struct aws_s3_meta_request_event event = {.type = AWS_S3_META_REQUEST_EVENT_PROGRESS};
+                            event.u.progress.info.bytes_transferred = bytes_previously_uploaded;
+                            event.u.progress.info.content_length = auto_ranged_put->content_length;
+                            aws_s3_meta_request_add_event_for_delivery_synced(meta_request, &event);
+                        }
                     }
                 }
 
@@ -1742,13 +1758,6 @@ static void s_s3_auto_ranged_put_request_finished(
                         etag = aws_strip_quotes(meta_request->allocator, etag_within_quotes);
                     }
                 }
-                if (error_code == AWS_ERROR_SUCCESS && meta_request->progress_callback != NULL) {
-                    struct aws_s3_meta_request_progress progress = {
-                        .bytes_transferred = request->request_body.len,
-                        .content_length = auto_ranged_put->content_length,
-                    };
-                    meta_request->progress_callback(meta_request, &progress, meta_request->user_data);
-                }
             }
 
             /* BEGIN CRITICAL SECTION */
@@ -1781,6 +1790,14 @@ static void s_s3_auto_ranged_put_request_finished(
                         AWS_ASSERT(etag != NULL);
 
                         ++auto_ranged_put->synced_data.num_parts_successful;
+
+                        /* Send progress_callback for delivery on io_event_loop thread */
+                        if (meta_request->progress_callback != NULL) {
+                            struct aws_s3_meta_request_event event = {.type = AWS_S3_META_REQUEST_EVENT_PROGRESS};
+                            event.u.progress.info.bytes_transferred = request->request_body.len;
+                            event.u.progress.info.content_length = auto_ranged_put->content_length;
+                            aws_s3_meta_request_add_event_for_delivery_synced(meta_request, &event);
+                        }
 
                         /* Store part's ETag */
                         struct aws_s3_mpu_part_info *part = NULL;

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -1481,8 +1481,7 @@ static void s_s3_client_prepare_callback_queue_request(
         request_is_noop = request->is_noop != 0;
         s_s3_client_meta_request_finished_request(client, meta_request, request, error_code);
 
-        aws_s3_request_release(request);
-        request = NULL;
+        request = aws_s3_request_release(request);
     }
 
     /* BEGIN CRITICAL SECTION */
@@ -1522,8 +1521,7 @@ void aws_s3_client_update_connections_threaded(struct aws_s3_client *client) {
         if (!request->always_send && aws_s3_meta_request_has_finish_result(request->meta_request)) {
             s_s3_client_meta_request_finished_request(client, request->meta_request, request, AWS_ERROR_S3_CANCELED);
 
-            aws_s3_request_release(request);
-            request = NULL;
+            request = aws_s3_request_release(request);
         } else if (
             s_s3_client_get_num_requests_network_io(client, request->meta_request->type) < max_active_connections) {
             s_s3_client_create_connection_for_request(client, request);
@@ -1856,8 +1854,8 @@ reset_connection:
     }
 
     if (connection->request != NULL) {
-        aws_s3_request_release(connection->request);
-        connection->request = NULL;
+
+        connection->request = aws_s3_request_release(connection->request);
     }
 
     aws_retry_token_release(connection->retry_token);

--- a/source/s3_copy_object.c
+++ b/source/s3_copy_object.c
@@ -443,6 +443,7 @@ static struct aws_future_void *s_s3_copy_object_prepare_request(struct aws_s3_re
         case AWS_S3_COPY_OBJECT_REQUEST_TAG_MULTIPART_COPY: {
             /* Create a new uploadPartCopy message to upload a part. */
             /* compute sub-request range */
+            /* note that range-end is inclusive */
             uint64_t range_start = (request->part_number - 1) * copy_object->synced_data.part_size;
             uint64_t range_end = range_start + copy_object->synced_data.part_size - 1;
             if (range_end >= copy_object->synced_data.content_length) {

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -1376,7 +1376,7 @@ void aws_s3_meta_request_stream_response_body_synced(
     struct aws_s3_request *next_streaming_request;
     while ((next_streaming_request = s_s3_meta_request_body_streaming_pop_next_synced(meta_request)) != NULL) {
         struct aws_s3_meta_request_event event = {.type = AWS_S3_META_REQUEST_EVENT_RESPONSE_BODY};
-        event.u.response_body.request = next_streaming_request; /* */
+        event.u.response_body.completed_request = next_streaming_request;
         aws_s3_meta_request_add_event_for_delivery_synced(meta_request, &event);
 
         ++num_streaming_requests;
@@ -1465,7 +1465,7 @@ static void s_s3_meta_request_event_delivery_task(struct aws_task *task, void *a
         switch (event.type) {
 
             case AWS_S3_META_REQUEST_EVENT_RESPONSE_BODY: {
-                struct aws_s3_request *request = event.u.response_body.request;
+                struct aws_s3_request *request = event.u.response_body.completed_request;
                 AWS_ASSERT(meta_request == request->meta_request);
                 struct aws_byte_cursor response_body = aws_byte_cursor_from_buf(&request->send_data.response_body);
 

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -25,6 +25,7 @@
 
 static const size_t s_dynamic_body_initial_buf_size = KB_TO_BYTES(1);
 static const size_t s_default_body_streaming_priority_queue_size = 16;
+static const size_t s_default_event_delivery_array_size = 16;
 
 static int s_s3_request_priority_queue_pred(const void *a, const void *b);
 static void s_s3_meta_request_destroy(void *user_data);
@@ -223,6 +224,18 @@ int aws_s3_meta_request_init_base(
         goto error;
     }
 
+    aws_array_list_init_dynamic(
+        &meta_request->synced_data.event_delivery_array,
+        meta_request->allocator,
+        s_default_event_delivery_array_size,
+        sizeof(struct aws_s3_meta_request_event));
+
+    aws_array_list_init_dynamic(
+        &meta_request->io_threaded_data.event_delivery_array,
+        meta_request->allocator,
+        s_default_event_delivery_array_size,
+        sizeof(struct aws_s3_meta_request_event));
+
     *((size_t *)&meta_request->part_size) = part_size;
     *((bool *)&meta_request->should_compute_content_md5) = should_compute_content_md5;
     checksum_config_init(&meta_request->checksum_config, options->checksum_config);
@@ -353,6 +366,16 @@ void aws_s3_meta_request_set_fail_synced(
     AWS_PRECONDITION(meta_request);
     ASSERT_SYNCED_DATA_LOCK_HELD(meta_request);
 
+    /* Protect against bugs */
+    if (error_code == AWS_ERROR_SUCCESS) {
+        AWS_ASSERT(false);
+        AWS_LOGF_ERROR(
+            AWS_LS_S3_META_REQUEST,
+            "id=%p Meta request failed but error code not set, AWS_ERROR_UNKNOWN will be reported",
+            (void *)meta_request);
+        error_code = AWS_ERROR_UNKNOWN;
+    }
+
     if (meta_request->synced_data.finish_result_set) {
         return;
     }
@@ -447,7 +470,15 @@ static void s_s3_meta_request_destroy(void *user_data) {
     aws_s3_endpoint_release(meta_request->endpoint);
     meta_request->client = aws_s3_client_release(meta_request->client);
 
+    AWS_ASSERT(aws_priority_queue_size(&meta_request->synced_data.pending_body_streaming_requests) == 0);
     aws_priority_queue_clean_up(&meta_request->synced_data.pending_body_streaming_requests);
+
+    AWS_ASSERT(aws_array_list_length(&meta_request->synced_data.event_delivery_array) == 0);
+    aws_array_list_clean_up(&meta_request->synced_data.event_delivery_array);
+
+    AWS_ASSERT(aws_array_list_length(&meta_request->io_threaded_data.event_delivery_array) == 0);
+    aws_array_list_clean_up(&meta_request->io_threaded_data.event_delivery_array);
+
     aws_s3_meta_request_result_clean_up(meta_request, &meta_request->synced_data.finish_result);
 
     if (meta_request->vtable != NULL) {
@@ -1309,12 +1340,6 @@ void aws_s3_meta_request_finished_request(
     meta_request->vtable->finished_request(meta_request, request, error_code);
 }
 
-struct s3_stream_response_body_payload {
-    struct aws_s3_meta_request *meta_request;
-    struct aws_linked_list requests;
-    struct aws_task task;
-};
-
 /* Pushes a request into the body streaming priority queue. Derived meta request types should not call this--they
  * should instead call aws_s3_meta_request_stream_response_body_synced.*/
 static void s_s3_meta_request_body_streaming_push_synced(
@@ -1327,18 +1352,16 @@ static void s_s3_meta_request_body_streaming_push_synced(
 static struct aws_s3_request *s_s3_meta_request_body_streaming_pop_next_synced(
     struct aws_s3_meta_request *meta_request);
 
-static void s_s3_meta_request_body_streaming_task(struct aws_task *task, void *arg, enum aws_task_status task_status);
+static void s_s3_meta_request_event_delivery_task(struct aws_task *task, void *arg, enum aws_task_status task_status);
 
 void aws_s3_meta_request_stream_response_body_synced(
     struct aws_s3_meta_request *meta_request,
     struct aws_s3_request *request) {
+
     ASSERT_SYNCED_DATA_LOCK_HELD(meta_request);
     AWS_PRECONDITION(meta_request);
     AWS_PRECONDITION(request);
     AWS_PRECONDITION(request->part_number > 0);
-
-    struct aws_linked_list streaming_requests;
-    aws_linked_list_init(&streaming_requests);
 
     /* Push it into the priority queue. */
     s_s3_meta_request_body_streaming_push_synced(meta_request, request);
@@ -1347,49 +1370,62 @@ void aws_s3_meta_request_stream_response_body_synced(
     AWS_PRECONDITION(client);
     aws_atomic_fetch_add(&client->stats.num_requests_stream_queued_waiting, 1);
 
-    /* Grab the next request that can be streamed back to the caller. */
-    struct aws_s3_request *next_streaming_request = s_s3_meta_request_body_streaming_pop_next_synced(meta_request);
+    /* Grab any requests that can be streamed back to the caller
+     * and send them for delivery on io_event_loop thread. */
     uint32_t num_streaming_requests = 0;
+    struct aws_s3_request *next_streaming_request;
+    while ((next_streaming_request = s_s3_meta_request_body_streaming_pop_next_synced(meta_request)) != NULL) {
+        struct aws_s3_meta_request_event event = {.type = AWS_S3_META_REQUEST_EVENT_RESPONSE_BODY};
+        event.u.response_body.request = next_streaming_request; /* */
+        aws_s3_meta_request_add_event_for_delivery_synced(meta_request, &event);
 
-    /* Grab any additional requests that could be streamed to the caller. */
-    while (next_streaming_request != NULL) {
-        aws_atomic_fetch_sub(&client->stats.num_requests_stream_queued_waiting, 1);
-
-        aws_linked_list_push_back(&streaming_requests, &next_streaming_request->node);
         ++num_streaming_requests;
-        next_streaming_request = s_s3_meta_request_body_streaming_pop_next_synced(meta_request);
     }
 
-    if (aws_linked_list_empty(&streaming_requests)) {
+    if (num_streaming_requests == 0) {
         return;
     }
 
     aws_atomic_fetch_add(&client->stats.num_requests_streaming, num_streaming_requests);
+    aws_atomic_fetch_sub(&client->stats.num_requests_stream_queued_waiting, num_streaming_requests);
 
     meta_request->synced_data.num_parts_delivery_sent += num_streaming_requests;
-
-    struct s3_stream_response_body_payload *payload =
-        aws_mem_calloc(client->allocator, 1, sizeof(struct s3_stream_response_body_payload));
-
-    aws_s3_meta_request_acquire(meta_request);
-    payload->meta_request = meta_request;
-
-    aws_linked_list_init(&payload->requests);
-    aws_linked_list_swap_contents(&payload->requests, &streaming_requests);
-
-    aws_task_init(
-        &payload->task, s_s3_meta_request_body_streaming_task, payload, "s_s3_meta_request_body_streaming_task");
-    aws_event_loop_schedule_task_now(meta_request->io_event_loop, &payload->task);
 }
 
-static void s_s3_meta_request_body_streaming_task(struct aws_task *task, void *arg, enum aws_task_status task_status) {
+void aws_s3_meta_request_add_event_for_delivery_synced(
+    struct aws_s3_meta_request *meta_request,
+    const struct aws_s3_meta_request_event *event) {
+
+    ASSERT_SYNCED_DATA_LOCK_HELD(meta_request);
+
+    aws_array_list_push_back(&meta_request->synced_data.event_delivery_array, event);
+
+    /* If the array was empty before, schedule task to deliver all events in the array.
+     * If the array already had things in it, then the task is already scheduled and will run soon. */
+    if (aws_array_list_length(&meta_request->synced_data.event_delivery_array) == 1) {
+        aws_s3_meta_request_acquire(meta_request);
+
+        aws_task_init(
+            &meta_request->synced_data.event_delivery_task,
+            s_s3_meta_request_event_delivery_task,
+            meta_request,
+            "s3_meta_request_event_delivery");
+        aws_event_loop_schedule_task_now(meta_request->io_event_loop, &meta_request->synced_data.event_delivery_task);
+    }
+}
+
+bool aws_s3_meta_request_are_events_out_for_delivery_synced(struct aws_s3_meta_request *meta_request) {
+    ASSERT_SYNCED_DATA_LOCK_HELD(meta_request);
+    return aws_array_list_length(&meta_request->synced_data.event_delivery_array) > 0 ||
+           meta_request->synced_data.event_delivery_active;
+}
+
+/* Deliver events in event_delivery_array.
+ * This task runs on the meta-request's io_event_loop thread. */
+static void s_s3_meta_request_event_delivery_task(struct aws_task *task, void *arg, enum aws_task_status task_status) {
     (void)task;
     (void)task_status;
-
-    struct s3_stream_response_body_payload *payload = arg;
-    AWS_PRECONDITION(payload);
-
-    struct aws_s3_meta_request *meta_request = payload->meta_request;
+    struct aws_s3_meta_request *meta_request = arg;
     AWS_PRECONDITION(meta_request);
     AWS_PRECONDITION(meta_request->vtable);
 
@@ -1399,40 +1435,98 @@ static void s_s3_meta_request_body_streaming_task(struct aws_task *task, void *a
     /* Client owns this event loop group. A cancel should not be possible. */
     AWS_ASSERT(task_status == AWS_TASK_STATUS_RUN_READY);
 
-    struct aws_linked_list completed_requests;
-    aws_linked_list_init(&completed_requests);
+    /* Swap contents of synced_data.event_delivery_array into this pre-allocated array-list, then process events */
+    struct aws_array_list *event_delivery_array = &meta_request->io_threaded_data.event_delivery_array;
+    AWS_FATAL_ASSERT(aws_array_list_length(event_delivery_array) == 0);
 
+    /* If an error occurs, don't fire callbacks anymore. */
     int error_code = AWS_ERROR_SUCCESS;
-    uint32_t num_successful = 0;
-    uint32_t num_failed = 0;
+    uint32_t num_parts_delivered = 0;
 
-    while (!aws_linked_list_empty(&payload->requests)) {
-        struct aws_linked_list_node *request_node = aws_linked_list_pop_front(&payload->requests);
-        struct aws_s3_request *request = AWS_CONTAINER_OF(request_node, struct aws_s3_request, node);
-        AWS_ASSERT(meta_request == request->meta_request);
-        struct aws_byte_cursor body_buffer_byte_cursor = aws_byte_cursor_from_buf(&request->send_data.response_body);
+    /* BEGIN CRITICAL SECTION */
+    {
+        aws_s3_meta_request_lock_synced_data(meta_request);
 
-        AWS_ASSERT(request->part_number >= 1);
+        aws_array_list_swap_contents(event_delivery_array, &meta_request->synced_data.event_delivery_array);
+        meta_request->synced_data.event_delivery_active = true;
 
-        if (aws_s3_meta_request_has_finish_result(meta_request)) {
-            ++num_failed;
-        } else {
-            if (body_buffer_byte_cursor.len > 0 && error_code == AWS_ERROR_SUCCESS && meta_request->body_callback &&
-                meta_request->body_callback(
-                    meta_request, &body_buffer_byte_cursor, request->part_range_start, meta_request->user_data)) {
-                error_code = aws_last_error_or_unknown();
-            }
-
-            if (error_code == AWS_ERROR_SUCCESS) {
-                ++num_successful;
-            } else {
-                ++num_failed;
-            }
+        if (aws_s3_meta_request_has_finish_result_synced(meta_request)) {
+            error_code = AWS_ERROR_S3_CANCELED;
         }
 
-        aws_atomic_fetch_sub(&client->stats.num_requests_streaming, 1);
-        aws_s3_request_release(request);
+        aws_s3_meta_request_unlock_synced_data(meta_request);
     }
+    /* END CRITICAL SECTION */
+
+    /* Deliver all events */
+    for (size_t event_i = 0; event_i < aws_array_list_length(event_delivery_array); ++event_i) {
+        struct aws_s3_meta_request_event event;
+        aws_array_list_get_at(event_delivery_array, &event, event_i);
+        switch (event.type) {
+
+            case AWS_S3_META_REQUEST_EVENT_RESPONSE_BODY: {
+                struct aws_s3_request *request = event.u.response_body.request;
+                AWS_ASSERT(meta_request == request->meta_request);
+                struct aws_byte_cursor response_body = aws_byte_cursor_from_buf(&request->send_data.response_body);
+
+                AWS_ASSERT(request->part_number >= 1);
+
+                if (error_code == AWS_ERROR_SUCCESS && response_body.len > 0 && meta_request->body_callback != NULL) {
+                    if (meta_request->body_callback(
+                            meta_request, &response_body, request->part_range_start, meta_request->user_data)) {
+
+                        error_code = aws_last_error_or_unknown();
+                        AWS_LOGF_ERROR(
+                            AWS_LS_S3_META_REQUEST,
+                            "id=%p Response body callback raised error %d (%s).",
+                            (void *)meta_request,
+                            error_code,
+                            aws_error_str(error_code));
+                    }
+                }
+
+                ++num_parts_delivered;
+                aws_s3_request_release(request);
+            } break;
+
+            case AWS_S3_META_REQUEST_EVENT_PROGRESS: {
+                if (error_code == AWS_ERROR_SUCCESS && meta_request->progress_callback != NULL) {
+                    /* Don't report 0 byte progress events.
+                     * The reasoning behind this is:
+                     *
+                     * In some code paths, when no data is transferred, there are no progress events,
+                     * but in other code paths there might be one progress event of 0 bytes.
+                     * We want to be consistent, either:
+                     * - REPORT AT LEAST ONCE: even if no data is being transferred.
+                     *   This would require finding every code path where no progress events are sent,
+                     *   and sending an appropriate progress event, even if it's for 0 bytes.
+                     *   One example of ending early is: when resuming a paused upload,
+                     *   we do ListParts on the UploadID, and if that 404s we assume the
+                     *   previous "paused" meta-request actually completed,
+                     *   and so we immediately end the "resuming" meta-request
+                     *   as successful without sending any further HTTP requests.
+                     *   It would be tough to accurately report progress here because
+                     *   we don't know the total size, since we never read the request body,
+                     *   and didn't get any info about the previous upload.
+                     * OR
+                     * - NEVER REPORT ZERO BYTES: even if that means no progress events at all.
+                     *   This is easy to do. We'd only send progress events when data is transferred,
+                     *   and if a 0 byte event slips through somehow, just check before firing the callback.
+                     * Since the NEVER REPORT ZERO BYTES path is simpler to implement, we went with that. */
+                    if (event.u.progress.info.bytes_transferred > 0) {
+                        meta_request->progress_callback(meta_request, &event.u.progress.info, meta_request->user_data);
+                    }
+                }
+            } break;
+
+            default:
+                AWS_FATAL_ASSERT(false);
+        }
+    }
+
+    /* Done delivering events */
+    aws_array_list_clear(event_delivery_array);
+
     /* BEGIN CRITICAL SECTION */
     {
         aws_s3_meta_request_lock_synced_data(meta_request);
@@ -1440,14 +1534,11 @@ static void s_s3_meta_request_body_streaming_task(struct aws_task *task, void *a
             aws_s3_meta_request_set_fail_synced(meta_request, NULL, error_code);
         }
 
-        meta_request->synced_data.num_parts_delivery_completed += (num_failed + num_successful);
-        meta_request->synced_data.num_parts_delivery_failed += num_failed;
-        meta_request->synced_data.num_parts_delivery_succeeded += num_successful;
+        meta_request->synced_data.num_parts_delivery_completed += num_parts_delivered;
+        meta_request->synced_data.event_delivery_active = false;
         aws_s3_meta_request_unlock_synced_data(meta_request);
     }
     /* END CRITICAL SECTION */
-    aws_mem_release(client->allocator, payload);
-    payload = NULL;
 
     aws_s3_client_schedule_process_work(client);
     aws_s3_meta_request_release(meta_request);

--- a/source/s3_request.c
+++ b/source/s3_request.c
@@ -102,18 +102,18 @@ void aws_s3_request_clean_up_send_data(struct aws_s3_request *request) {
     AWS_ZERO_STRUCT(request->send_data);
 }
 
-void aws_s3_request_acquire(struct aws_s3_request *request) {
-    AWS_PRECONDITION(request);
-
-    aws_ref_count_acquire(&request->ref_count);
+struct aws_s3_request *aws_s3_request_acquire(struct aws_s3_request *request) {
+    if (request != NULL) {
+        aws_ref_count_acquire(&request->ref_count);
+    }
+    return request;
 }
 
-void aws_s3_request_release(struct aws_s3_request *request) {
-    if (request == NULL) {
-        return;
+struct aws_s3_request *aws_s3_request_release(struct aws_s3_request *request) {
+    if (request != NULL) {
+        aws_ref_count_release(&request->ref_count);
     }
-
-    aws_ref_count_release(&request->ref_count);
+    return NULL;
 }
 
 static void s_s3_request_destroy(void *user_data) {

--- a/source/s3_util.c
+++ b/source/s3_util.c
@@ -470,7 +470,7 @@ uint32_t aws_s3_get_num_parts(size_t part_size, uint64_t object_range_start, uin
 
     /* If the range has room for a second part, calculate the additional amount of parts. */
     if (second_part_start <= object_range_end) {
-        uint64_t aligned_range_remainder = object_range_end + 1 - second_part_start;
+        uint64_t aligned_range_remainder = object_range_end + 1 - second_part_start; /* range-end is inclusive */
         num_parts += (uint32_t)(aligned_range_remainder / (uint64_t)part_size);
 
         if ((aligned_range_remainder % part_size) > 0) {
@@ -515,7 +515,7 @@ void aws_s3_get_part_range(
         /* Else, find the next part by adding the object range + total number of whole parts before this one + initial
          * part size*/
         *out_part_range_start = object_range_start + ((uint64_t)(part_index - 1)) * part_size_uint64 + first_part_size;
-        *out_part_range_end = *out_part_range_start + part_size_uint64 - 1;
+        *out_part_range_end = *out_part_range_start + part_size_uint64 - 1; /* range-end is inclusive */
     }
 
     /* Cap the part's range end using the object's range end. */

--- a/tests/s3_data_plane_tests.c
+++ b/tests/s3_data_plane_tests.c
@@ -5325,6 +5325,7 @@ static void s_copy_object_meta_request_progress_callback(
     const struct aws_s3_meta_request_progress *progress,
     void *user_data) {
 
+    (void)meta_request;
     struct copy_object_test_data *test_data = user_data;
 
     aws_mutex_lock(&test_data->mutex);

--- a/tests/s3_mock_server_tests.c
+++ b/tests/s3_mock_server_tests.c
@@ -589,8 +589,7 @@ TEST_CASE(resume_first_part_not_completed_mock_server) {
 
     ASSERT_SUCCESS(aws_s3_tester_send_meta_request_with_options(&tester, &put_options, &out_results));
     /* Make Sure we only uploaded 2 parts. */
-    size_t total_bytes_uploaded = aws_atomic_load_int(&out_results.total_bytes_uploaded);
-    ASSERT_UINT_EQUALS(2 * MB_TO_BYTES(8), total_bytes_uploaded);
+    /* TODO: monitor telemetry ensure this happened */
 
     aws_s3_meta_request_test_results_clean_up(&out_results);
     aws_s3_meta_request_resume_token_release(token);
@@ -646,8 +645,7 @@ TEST_CASE(resume_multi_page_list_parts_mock_server) {
 
     ASSERT_SUCCESS(aws_s3_tester_send_meta_request_with_options(&tester, &put_options, &out_results));
     /* Make Sure we only uploaded 2 parts. */
-    size_t total_bytes_uploaded = aws_atomic_load_int(&out_results.total_bytes_uploaded);
-    ASSERT_UINT_EQUALS(2 * MB_TO_BYTES(8), total_bytes_uploaded);
+    /* TODO: monitor telemetry ensure this happened */
 
     aws_s3_meta_request_test_results_clean_up(&out_results);
     aws_s3_meta_request_resume_token_release(token);
@@ -755,8 +753,7 @@ TEST_CASE(resume_after_finished_mock_server) {
     ASSERT_SUCCESS(aws_s3_tester_send_meta_request_with_options(&tester, &put_options, &out_results));
     /* The error code should be success, but there are no headers and stuff as no request was made. */
     ASSERT_UINT_EQUALS(AWS_ERROR_SUCCESS, out_results.finished_error_code);
-    size_t total_bytes_uploaded = aws_atomic_load_int(&out_results.total_bytes_uploaded);
-    ASSERT_UINT_EQUALS(0, total_bytes_uploaded);
+    /* TODO: monitor telemetry to ensure no actual data was sent */
 
     aws_s3_meta_request_test_results_clean_up(&out_results);
     aws_s3_meta_request_resume_token_release(token);

--- a/tests/s3_mock_server_tests.c
+++ b/tests/s3_mock_server_tests.c
@@ -831,9 +831,6 @@ TEST_CASE(endpoint_override_mock_server) {
         .mock_server = true,
     };
 
-    struct aws_s3_meta_request_test_results out_results;
-    aws_s3_meta_request_test_results_init(&out_results, allocator);
-
     /* Put together a simple S3 Put Object request. */
     struct aws_input_stream *input_stream =
         aws_s3_test_input_stream_new(allocator, put_options.put_options.object_size_mb);
@@ -843,7 +840,7 @@ TEST_CASE(endpoint_override_mock_server) {
 
     /* 1. Create request without host and use endpoint override for the host info */
     put_options.message = message;
-    ASSERT_SUCCESS(aws_s3_tester_send_meta_request_with_options(&tester, &put_options, &out_results));
+    ASSERT_SUCCESS(aws_s3_tester_send_meta_request_with_options(&tester, &put_options, NULL));
 
     /* 2. Create request with host info missmatch endpoint override */
     struct aws_http_header host_header = {
@@ -853,12 +850,11 @@ TEST_CASE(endpoint_override_mock_server) {
     ASSERT_SUCCESS(aws_http_message_add_header(message, host_header));
     put_options.message = message;
     put_options.validate_type = AWS_S3_TESTER_VALIDATE_TYPE_EXPECT_FAILURE;
-    ASSERT_SUCCESS(aws_s3_tester_send_meta_request_with_options(&tester, &put_options, &out_results));
+    ASSERT_SUCCESS(aws_s3_tester_send_meta_request_with_options(&tester, &put_options, NULL));
 
     /* Clean up */
     aws_http_message_destroy(message);
     aws_input_stream_release(input_stream);
-    aws_s3_meta_request_test_results_clean_up(&out_results);
     aws_s3_client_release(client);
     aws_s3_tester_clean_up(&tester);
 

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -1627,6 +1627,14 @@ int aws_s3_tester_send_meta_request_with_options(
         aws_string_destroy(host_name);
     } else {
         aws_http_message_acquire(meta_request_options.message);
+
+        if (options->meta_request_type == AWS_S3_META_REQUEST_TYPE_PUT_OBJECT) {
+            /* Figure out how much is being uploaded from pre-existing message */
+            struct aws_input_stream *input_stream = aws_http_message_get_body_stream(meta_request_options.message);
+            if (input_stream != NULL) {
+                ASSERT_SUCCESS(aws_input_stream_get_length(input_stream, (int64_t *)&upload_size_bytes));
+            }
+        }
     }
 
     struct aws_s3_meta_request_test_results meta_request_test_results;

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -246,7 +246,7 @@ static void s_s3_test_meta_request_progress(
     struct aws_s3_meta_request_test_results *meta_request_test_results = user_data;
 
     meta_request_test_results->progress.invoked_count += 1;
-    meta_request_test_results->progress.total_bytes += progress->bytes_transferred;
+    meta_request_test_results->progress.total_bytes_transferred += progress->bytes_transferred;
 
     /* Once content_length is reported, it shouldn't change */
     if (meta_request_test_results->progress.content_length == 0) {
@@ -257,7 +257,7 @@ static void s_s3_test_meta_request_progress(
 
     /* If content_length is known, we shouldn't go over it */
     if (progress->content_length != 0) {
-        AWS_FATAL_ASSERT(meta_request_test_results->progress.total_bytes <= progress->content_length);
+        AWS_FATAL_ASSERT(meta_request_test_results->progress.total_bytes_transferred <= progress->content_length);
     }
 
     if (meta_request_test_results->progress_callback != NULL) {
@@ -1685,7 +1685,7 @@ int aws_s3_tester_send_meta_request_with_options(
                     ASSERT_UINT_EQUALS(upload_size_bytes, aws_async_input_stream_tester_total_bytes_read(async_stream));
                 }
 
-                ASSERT_UINT_EQUALS(upload_size_bytes, out_results->progress.total_bytes);
+                ASSERT_UINT_EQUALS(upload_size_bytes, out_results->progress.total_bytes_transferred);
                 if (!options->put_options.skip_content_length) {
                     ASSERT_UINT_EQUALS(upload_size_bytes, out_results->progress.content_length);
                 }
@@ -1875,7 +1875,7 @@ int aws_s3_tester_validate_get_object_results(
         meta_request_test_results->received_body_size);
 
     ASSERT_TRUE(content_length == meta_request_test_results->received_body_size);
-    ASSERT_UINT_EQUALS(content_length, meta_request_test_results->progress.total_bytes);
+    ASSERT_UINT_EQUALS(content_length, meta_request_test_results->progress.total_bytes_transferred);
     ASSERT_UINT_EQUALS(content_length, meta_request_test_results->progress.content_length);
 
     return AWS_OP_SUCCESS;

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -245,7 +245,6 @@ static void s_s3_test_meta_request_progress(
 
     struct aws_s3_meta_request_test_results *meta_request_test_results = user_data;
 
-    meta_request_test_results->progress.invoked_count += 1;
     meta_request_test_results->progress.total_bytes_transferred += progress->bytes_transferred;
 
     /* Once content_length is reported, it shouldn't change */
@@ -1630,9 +1629,9 @@ int aws_s3_tester_send_meta_request_with_options(
 
         if (options->meta_request_type == AWS_S3_META_REQUEST_TYPE_PUT_OBJECT) {
             /* Figure out how much is being uploaded from pre-existing message */
-            struct aws_input_stream *input_stream = aws_http_message_get_body_stream(meta_request_options.message);
-            if (input_stream != NULL) {
-                ASSERT_SUCCESS(aws_input_stream_get_length(input_stream, (int64_t *)&upload_size_bytes));
+            struct aws_input_stream *mystery_stream = aws_http_message_get_body_stream(meta_request_options.message);
+            if (mystery_stream != NULL) {
+                ASSERT_SUCCESS(aws_input_stream_get_length(mystery_stream, (int64_t *)&upload_size_bytes));
             }
         }
     }

--- a/tests/s3_tester.h
+++ b/tests/s3_tester.h
@@ -235,9 +235,9 @@ struct aws_s3_meta_request_test_results {
 
     /* Record data from progress_callback() */
     struct {
-        size_t invoked_count;    /* Number of times callback invoked */
-        uint64_t content_length; /* Remember progress->content_length */
-        uint64_t total_bytes;    /* Accumulator for progress->progress_bytes */
+        size_t invoked_count;             /* Number of times callback invoked */
+        uint64_t content_length;          /* Remember progress->content_length */
+        uint64_t total_bytes_transferred; /* Accumulator for progress->bytes_transferred */
     } progress;
 
     /* Protected the tester->synced_data.lock */

--- a/tests/s3_tester.h
+++ b/tests/s3_tester.h
@@ -235,7 +235,6 @@ struct aws_s3_meta_request_test_results {
 
     /* Record data from progress_callback() */
     struct {
-        size_t invoked_count;             /* Number of times callback invoked */
         uint64_t content_length;          /* Remember progress->content_length */
         uint64_t total_bytes_transferred; /* Accumulator for progress->bytes_transferred */
     } progress;

--- a/tests/s3_tester.h
+++ b/tests/s3_tester.h
@@ -233,10 +233,12 @@ struct aws_s3_meta_request_test_results {
     int finished_error_code;
     enum aws_s3_checksum_algorithm algorithm;
 
-    /* accumulator of amount of bytes uploaded.
-     * Currently, this only works for MPU and Copy meta-requests.
-     * It's powered by the progress_callback which isn't invoked for all types */
-    struct aws_atomic_var total_bytes_uploaded;
+    /* Record data from progress_callback() */
+    struct {
+        size_t invoked_count;    /* Number of times callback invoked */
+        uint64_t total_bytes;    /* Accumulator for progress_bytes */
+        uint64_t content_length; /* Store info->content_legnth */
+    } progress;
 
     /* Protected the tester->synced_data.lock */
     struct {

--- a/tests/s3_tester.h
+++ b/tests/s3_tester.h
@@ -236,8 +236,8 @@ struct aws_s3_meta_request_test_results {
     /* Record data from progress_callback() */
     struct {
         size_t invoked_count;    /* Number of times callback invoked */
-        uint64_t total_bytes;    /* Accumulator for progress_bytes */
-        uint64_t content_length; /* Store info->content_legnth */
+        uint64_t content_length; /* Remember progress->content_length */
+        uint64_t total_bytes;    /* Accumulator for progress->progress_bytes */
     } progress;
 
     /* Protected the tester->synced_data.lock */


### PR DESCRIPTION
**Description of changes:**
- progress_callback is now invoked for all meta-request types.
  -  Previously, it was only invoked for multi-part PUT and multi-part COPY. It wasn't invoked when PUT or COPY was done as a single-part operation, and wasn't invoked for any type of GET.
- progress_callbacks now fire sequentially, and do not overlap with the meta-request's other callbacks.
  - Previously, progress_callbacks could fire on different threads and overlap with each other (and overlap the body_callback).
  - TODO: telemetry_callback can still overlap with other callbacks. We should give it the same treatment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
