### PR TITLE
Use mmap to for parallel read streams

### DIFF
--- a/include/aws/s3/private/aws_mmap.h
+++ b/include/aws/s3/private/aws_mmap.h
@@ -17,10 +17,7 @@ struct aws_allocator;
 
 AWS_EXTERN_C_BEGIN
 
-struct aws_mmap_context {
-    void *impl;
-    const char *content;
-};
+struct aws_mmap_context;
 
 /**
  * TODO: supports different mode and extra.
@@ -32,6 +29,25 @@ AWS_S3_API struct aws_mmap_context *aws_mmap_context_new(struct aws_allocator *a
  * TODO: real refcount.
  */
 AWS_S3_API struct aws_mmap_context *aws_mmap_context_release(struct aws_mmap_context *context);
+
+/**
+ * Get mapped content. OS will load the content into memory when the content is accessed.
+ * You need to invoke `aws_mmap_context_unmap_content` once read from the memory, otherwise, leak will happen
+ *
+ * @param context       The mmap context
+ * @return              The mapped address
+ **/
+AWS_S3_API void *aws_mmap_context_map_content(struct aws_mmap_context *context);
+
+/**
+ * Remove any mappings for those entire pages containing any part of the address space of the process starting at addr
+ * and continuing for len bytes
+ *
+ * @param mapped_addr   The start address of the mapped content
+ * @param len           The length to free
+ * @return AWS_OP_SUCCESS on succes, AWS_OP_ERR on error.
+ **/
+AWS_S3_API int aws_mmap_context_unmap_content(void *mapped_addr, size_t len);
 
 AWS_EXTERN_C_END
 #endif /* AWS_MMAP_H */

--- a/include/aws/s3/private/aws_mmap.h
+++ b/include/aws/s3/private/aws_mmap.h
@@ -7,6 +7,10 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/**
+ * TODO: move this to part of <aws/common/file.h> instead
+ */
+
 #include <aws/s3/s3.h>
 
 struct aws_allocator;
@@ -18,8 +22,15 @@ struct aws_mmap_context {
     const char *content;
 };
 
+/**
+ * TODO: supports different mode and extra.
+ * Create a READ-ONLY mmap context.
+ */
 AWS_S3_API struct aws_mmap_context *aws_mmap_context_new(struct aws_allocator *allocator, const char *file_name);
 
+/**
+ * TODO: real refcount.
+ */
 AWS_S3_API struct aws_mmap_context *aws_mmap_context_release(struct aws_mmap_context *context);
 
 AWS_EXTERN_C_END

--- a/include/aws/s3/private/aws_mmap.h
+++ b/include/aws/s3/private/aws_mmap.h
@@ -32,12 +32,21 @@ AWS_S3_API struct aws_mmap_context *aws_mmap_context_release(struct aws_mmap_con
 
 /**
  * Get mapped content. OS will load the content into memory when the content is accessed.
- * You need to invoke `aws_mmap_context_unmap_content` once read from the memory, otherwise, leak will happen
+ * You need to invoke `aws_mmap_context_unmap_content` on the `out_start_addr` once read from the memory is done,
+ * otherwise, leak will happen
  *
- * @param context       The mmap context
- * @return              The mapped address
+ * @param context           The mmap context
+ * @param length            The length of memory to map
+ * @param offset            The offset starting at the file to map.
+ * @param out_start_addr    The start address for the mapped memory, it will be a multiple
+ *                          of the page size as returned by sysconf(_SC_PAGE_SIZE)
+ * @return                  The mapped address starts from `offset` of the file
  **/
-AWS_S3_API void *aws_mmap_context_map_content(struct aws_mmap_context *context);
+AWS_S3_API void *aws_mmap_context_map_content(
+    struct aws_mmap_context *context,
+    size_t length,
+    size_t offset,
+    void **out_start_addr);
 
 /**
  * Remove any mappings for those entire pages containing any part of the address space of the process starting at addr
@@ -45,7 +54,7 @@ AWS_S3_API void *aws_mmap_context_map_content(struct aws_mmap_context *context);
  *
  * @param mapped_addr   The start address of the mapped content
  * @param len           The length to free
- * @return AWS_OP_SUCCESS on succes, AWS_OP_ERR on error.
+ * @return AWS_OP_SUCCESS on success, AWS_OP_ERR on error.
  **/
 AWS_S3_API int aws_mmap_context_unmap_content(void *mapped_addr, size_t len);
 

--- a/include/aws/s3/private/aws_mmap.h
+++ b/include/aws/s3/private/aws_mmap.h
@@ -1,0 +1,26 @@
+
+#ifndef AWS_MMAP_H
+#define AWS_MMAP_H
+
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/s3/s3.h>
+
+struct aws_allocator;
+
+AWS_EXTERN_C_BEGIN
+
+struct aws_mmap_context {
+    void *impl;
+    const char *content;
+};
+
+AWS_S3_API struct aws_mmap_context *aws_mmap_context_new(struct aws_allocator *allocator, const char *file_name);
+
+AWS_S3_API struct aws_mmap_context *aws_mmap_context_release(struct aws_mmap_context *context);
+
+AWS_EXTERN_C_END
+#endif /* AWS_MMAP_H */

--- a/include/aws/s3/private/s3_parallel_read_stream.h
+++ b/include/aws/s3/private/s3_parallel_read_stream.h
@@ -111,7 +111,7 @@ struct aws_future_bool *aws_parallel_input_stream_read(
 AWS_S3_API
 struct aws_parallel_input_stream *aws_parallel_input_stream_new_from_file(
     struct aws_allocator *allocator,
-    struct aws_byte_cursor file_name,
+    const char *file_name,
     struct aws_event_loop_group *reading_elg,
     size_t num_workers);
 

--- a/source/aws_mmap.c
+++ b/source/aws_mmap.c
@@ -1,3 +1,9 @@
+
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 #include "aws/s3/private/aws_mmap.h"
 #include <aws/common/allocator.h>
 
@@ -14,8 +20,69 @@
 #include <stdlib.h>
 
 #ifdef _WIN32
-struct aws_mmap_context *aws_mmap_new(const char *file_name) {
-    return "";
+struct aws_mmap_context_win_impl {
+    struct aws_allocator *allocator;
+
+    HANDLE hFile;
+    HANDLE hMapping;
+    LPVOID lpMapAddress;
+};
+
+struct aws_mmap_context *s_mmap_context_destroy(struct aws_mmap_context *context) {
+    if (!context) {
+        return NULL;
+    }
+    struct aws_mmap_context_win_impl *impl = context->impl;
+    if (impl->lpMapAddress) {
+        UnmapViewOfFile(impl->lpMapAddress);
+    }
+    if (impl->hMapping) {
+        CloseHandle(impl->hMapping);
+    }
+    if (impl->hFile) {
+        CloseHandle(impl->hFile);
+    }
+    aws_mem_release(impl->allocator, context);
+    return NULL;
+}
+
+struct aws_mmap_context *aws_mmap_context_release(struct aws_mmap_context *context) {
+    return s_mmap_context_destroy(context);
+}
+
+struct aws_mmap_context *aws_mmap_context_new(struct aws_allocator *allocator, const char *file_name) {
+    struct aws_mmap_context *context = NULL;
+    struct aws_mmap_context_win_impl *impl = NULL;
+    aws_mem_acquire_many(
+        allocator, 2, &context, sizeof(struct aws_mmap_context), &impl, sizeof(struct aws_mmap_context_win_impl));
+
+    impl->allocator = allocator;
+    impl->hFile = CreateFile(
+        file_name,
+        GENERIC_READ,
+        FILE_SHARE_READ,
+        NULL /*SecurityAttributes*/,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        NULL /*TemplateFile*/);
+    if (impl->hFile == INVALID_HANDLE_VALUE) {
+        goto error;
+    }
+    impl->hMapping = CreateFileMapping(impl->hFile, NULL, PAGE_READONLY, 0, 0, NULL /*Name*/);
+    if (impl->hMapping == NULL) {
+        goto error;
+    }
+    impl->lpMapAddress = MapViewOfFile(impl->hMapping, FILE_MAP_READ, 0, 0, 0);
+    if (impl->lpMapAddress == NULL) {
+        goto error;
+    }
+
+    context->content = (char *)impl->lpMapAddress;
+    context->impl = impl;
+    return context;
+error:
+    /* TODO: LOG and raise AWS ERRORs */
+    return s_mmap_context_destroy(context);
 }
 #else
 

--- a/source/aws_mmap.c
+++ b/source/aws_mmap.c
@@ -71,7 +71,11 @@ void *aws_mmap_context_map_content(
     DWORD page_starts_offset_low = (DWORD)(page_starts_offset & 0xFFFFFFFF);
 
     void *mapped_address = MapViewOfFile(
-        impl->mapping_handler, FILE_MAP_READ, page_starts_offset_high, page_starts_offset_low, length + in_page_offset);
+        impl->mapping_handler,
+        FILE_MAP_READ,
+        page_starts_offset_high,
+        page_starts_offset_low,
+        (SIZE_T)(length + in_page_offset));
     if (mapped_address == NULL) {
         goto error;
     }

--- a/source/aws_mmap.c
+++ b/source/aws_mmap.c
@@ -1,0 +1,71 @@
+#include "aws/s3/private/aws_mmap.h"
+#include <aws/common/allocator.h>
+
+#ifdef _WIN32
+#    include <windows.h>
+#else
+#    include <sys/mman.h>
+#    include <sys/stat.h>
+#    include <unistd.h>
+#endif /* _WIN32 */
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef _WIN32
+struct aws_mmap_context *aws_mmap_new(const char *file_name) {
+    return "";
+}
+#else
+
+struct aws_mmap_context_posix_impl {
+    struct aws_allocator *allocator;
+    int fd;
+};
+
+struct aws_mmap_context *s_mmap_context_destroy(struct aws_mmap_context *context) {
+    if (!context) {
+        return NULL;
+    }
+    struct aws_mmap_context_posix_impl *impl = context->impl;
+    if (impl->fd) {
+        close(impl->fd);
+    }
+    aws_mem_release(impl->allocator, context);
+    return NULL;
+}
+
+struct aws_mmap_context *aws_mmap_context_release(struct aws_mmap_context *context) {
+    return s_mmap_context_destroy(context);
+}
+
+struct aws_mmap_context *aws_mmap_context_new(struct aws_allocator *allocator, const char *file_name) {
+    struct aws_mmap_context *context = NULL;
+    struct aws_mmap_context_posix_impl *impl = NULL;
+    aws_mem_acquire_many(
+        allocator, 2, &context, sizeof(struct aws_mmap_context), &impl, sizeof(struct aws_mmap_context_posix_impl));
+
+    impl->fd = open(file_name, O_RDWR);
+    impl->allocator = allocator;
+    if (impl->fd == -1) {
+        goto error;
+    }
+
+    struct stat file_stat;
+    if (fstat(impl->fd, &file_stat) == -1) {
+        goto error;
+    }
+    void *mapped_data = mmap(NULL, file_stat.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, impl->fd, 0);
+    if (mapped_data == MAP_FAILED) {
+        goto error;
+    }
+
+    context->content = (char *)mapped_data;
+    context->impl = impl;
+    return context;
+error:
+    /* TODO: LOG and raise AWS ERRORs */
+    return s_mmap_context_destroy(context);
+}
+#endif /* _WIN32 */

--- a/source/aws_mmap.c
+++ b/source/aws_mmap.c
@@ -189,6 +189,13 @@ int aws_mmap_context_unmap_content(void *mapped_addr, size_t len) {
         return AWS_OP_SUCCESS;
     }
     if (munmap(mapped_addr, len)) {
+        /**
+         * Remove any mappings for those entire pages containing any part of the address space of the process starting
+         * at addr and continuing for len bytes.
+         *
+         * So, even if the len is not the exact match of the length of bytes we mapped, we will still free the number of
+         * pages we allocated.
+         **/
 
         return aws_translate_and_raise_io_error(errno);
     }

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -262,7 +262,7 @@ int aws_s3_meta_request_init_base(
         struct aws_string *file_path_str = aws_string_new_from_cursor(allocator, &options->send_filepath);
         meta_request->request_body_parallel_stream = aws_parallel_input_stream_new_from_file(
             allocator, aws_string_c_str(file_path_str), client->body_streaming_elg, 8 /* num_workers */);
-
+        aws_string_destroy(file_path_str);
         if (meta_request->request_body_parallel_stream == NULL) {
             goto error;
         }

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -258,8 +258,11 @@ int aws_s3_meta_request_init_base(
         /* Create parallel read stream from file */
         meta_request->initial_request_message = aws_http_message_acquire(options->message);
         AWS_ASSERT(client != NULL);
+        /* TODO: cannot just use the ptr* */
+        struct aws_string *file_path_str = aws_string_new_from_cursor(allocator, &options->send_filepath);
         meta_request->request_body_parallel_stream = aws_parallel_input_stream_new_from_file(
-            allocator, options->send_filepath, client->body_streaming_elg, 8 /* num_workers */);
+            allocator, aws_string_c_str(file_path_str), client->body_streaming_elg, 8 /* num_workers */);
+
         if (meta_request->request_body_parallel_stream == NULL) {
             goto error;
         }

--- a/source/s3_parallel_read_stream.c
+++ b/source/s3_parallel_read_stream.c
@@ -113,6 +113,7 @@ static void s_s3_parallel_from_file_read_task(struct aws_task *task, void *arg, 
     struct aws_future_bool *end_future = args->end_future;
 
     memcpy(args->dest->buffer, args->content + args->start_position, args->dest->capacity - args->dest->len);
+    args->dest->len = args->dest->capacity;
 
     error_occurred = false;
 

--- a/source/s3_parallel_read_stream.c
+++ b/source/s3_parallel_read_stream.c
@@ -117,7 +117,6 @@ static void s_s3_parallel_from_file_read_task(struct aws_task *task, void *arg, 
 
     error_occurred = false;
 
-done:
     aws_mem_release(args->alloc, task);
     if (error_occurred) {
         AWS_LOGF_TRACE(

--- a/source/s3_parallel_read_stream.c
+++ b/source/s3_parallel_read_stream.c
@@ -14,6 +14,13 @@
 #include <aws/io/future.h>
 #include <aws/io/stream.h>
 
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 void aws_parallel_input_stream_init_base(
     struct aws_parallel_input_stream *stream,
     struct aws_allocator *alloc,
@@ -61,12 +68,14 @@ struct aws_future_bool *aws_parallel_input_stream_read(
 struct aws_parallel_input_stream_from_file_impl {
     struct aws_parallel_input_stream base;
 
-    struct aws_string *file_path;
+    int fd;
+    size_t file_size;
+    char *content;
+
     struct aws_event_loop_group *reading_elg;
     size_t num_workers;
 
     struct aws_event_loop **assigned_event_loops;
-    struct aws_input_stream **assigned_file_streams;
 
     struct aws_atomic_var read_count;
 };
@@ -74,15 +83,10 @@ struct aws_parallel_input_stream_from_file_impl {
 static void s_para_from_file_destroy(struct aws_parallel_input_stream *stream) {
     struct aws_parallel_input_stream_from_file_impl *impl =
         AWS_CONTAINER_OF(stream, struct aws_parallel_input_stream_from_file_impl, base);
-
-    aws_string_destroy(impl->file_path);
-    for (size_t i = 0; i < impl->num_workers; i++) {
-        aws_input_stream_release(impl->assigned_file_streams[i]);
-    }
+    close(impl->fd);
 
     aws_event_loop_group_release(impl->reading_elg);
     aws_mem_release(stream->alloc, impl->assigned_event_loops);
-    aws_mem_release(stream->alloc, impl->assigned_file_streams);
 
     aws_mem_release(stream->alloc, impl);
 
@@ -97,7 +101,7 @@ struct aws_parallel_read_from_file_task_args {
     size_t start_position;
     struct aws_future_bool *end_future;
     struct aws_byte_buf *dest;
-    struct aws_input_stream *file_stream;
+    char *content;
 };
 
 static void s_s3_parallel_from_file_read_task(struct aws_task *task, void *arg, enum aws_task_status task_status) {
@@ -108,14 +112,7 @@ static void s_s3_parallel_from_file_read_task(struct aws_task *task, void *arg, 
     AWS_ASSERT(task_status == AWS_TASK_STATUS_RUN_READY);
     struct aws_future_bool *end_future = args->end_future;
 
-    if (aws_input_stream_seek(args->file_stream, (int64_t)args->start_position, AWS_SSB_BEGIN)) {
-        goto done;
-    }
-
-    /* TODO: check how many we read, check we read as expected */
-    if (aws_input_stream_read(args->file_stream, args->dest)) {
-        goto done;
-    }
+    memcpy(args->dest->buffer, args->content + args->start_position, args->dest->capacity - args->dest->len);
 
     error_occurred = false;
 
@@ -177,7 +174,6 @@ struct aws_future_bool *s_para_from_file_read(
 
     /* file handler will be assigned to the same loop every time. */
     struct aws_event_loop *loop = impl->assigned_event_loops[index];
-    struct aws_input_stream *file_stream = impl->assigned_file_streams[index];
     struct aws_task *read_task = aws_mem_calloc(impl->base.alloc, 1, sizeof(struct aws_task));
     struct aws_parallel_read_from_file_task_args *task_args =
         aws_mem_calloc(impl->base.alloc, 1, sizeof(struct aws_parallel_read_from_file_task_args));
@@ -186,7 +182,7 @@ struct aws_future_bool *s_para_from_file_read(
     task_args->start_position = start_position;
     task_args->dest = dest;
     task_args->end_future = aws_future_bool_acquire(future);
-    task_args->file_stream = file_stream;
+    task_args->content = impl->content;
     task_args->log_id = &impl->base;
 
     aws_task_init(read_task, s_s3_parallel_from_file_read_task, task_args, "s3_parallel_read_task");
@@ -209,28 +205,40 @@ static struct aws_parallel_input_stream_vtable s_parallel_input_stream_from_file
 
 struct aws_parallel_input_stream *aws_parallel_input_stream_new_from_file(
     struct aws_allocator *allocator,
-    struct aws_byte_cursor file_name,
+    const char *file_name,
     struct aws_event_loop_group *reading_elg,
     size_t num_workers) {
 
     struct aws_parallel_input_stream_from_file_impl *impl =
         aws_mem_calloc(allocator, 1, sizeof(struct aws_parallel_input_stream_from_file_impl));
-    impl->file_path = aws_string_new_from_cursor(allocator, &file_name);
     impl->reading_elg = aws_event_loop_group_acquire(reading_elg);
     impl->num_workers = num_workers;
     aws_parallel_input_stream_init_base(&impl->base, allocator, &s_parallel_input_stream_from_file_vtable, impl);
 
     aws_atomic_store_int(&impl->read_count, 0);
     impl->assigned_event_loops = aws_mem_calloc(allocator, num_workers, sizeof(struct aws_event_loop *));
-    impl->assigned_file_streams = aws_mem_calloc(allocator, num_workers, sizeof(struct aws_input_stream *));
+
+    impl->fd = open(file_name, O_RDWR);
+    if (impl->fd == -1) {
+        /* LOG */
+        goto error;
+    }
+
+    struct stat file_stat;
+    if (fstat(impl->fd, &file_stat) == -1) {
+        goto error;
+    }
+    impl->file_size = (size_t)file_stat.st_size;
+    void *mapped_data = mmap(NULL, file_stat.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, impl->fd, 0);
+    if (mapped_data == MAP_FAILED) {
+        goto error;
+    }
+
+    // Now, you can work with the mapped data as if it were an array
+    impl->content = (char *)mapped_data;
 
     for (size_t i = 0; i < num_workers; i++) {
         impl->assigned_event_loops[i] = aws_event_loop_group_get_next_loop(reading_elg);
-        impl->assigned_file_streams[i] = aws_input_stream_new_from_file(allocator, aws_string_c_str(impl->file_path));
-        if (!impl->assigned_file_streams[i]) {
-            AWS_LOGF_ERROR(AWS_LS_S3_PARALLEL_INPUT_STREAM, "id=%p: Error during fopen", (void *)&impl->base);
-            goto error;
-        }
     }
 
     return &impl->base;

--- a/source/s3_parallel_read_stream.c
+++ b/source/s3_parallel_read_stream.c
@@ -15,13 +15,6 @@
 #include <aws/io/future.h>
 #include <aws/io/stream.h>
 
-#include <fcntl.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
 void aws_parallel_input_stream_init_base(
     struct aws_parallel_input_stream *stream,
     struct aws_allocator *alloc,

--- a/tests/s3_parallel_read_stream_test.c
+++ b/tests/s3_parallel_read_stream_test.c
@@ -154,7 +154,7 @@ TEST_CASE(parallel_read_stream_from_file_sanity_test) {
     ASSERT_SUCCESS(s_create_read_file(file_path, s_parallel_stream_test->len));
 
     struct aws_parallel_input_stream *parallel_read_stream =
-        aws_parallel_input_stream_new_from_file(allocator, aws_byte_cursor_from_c_str(file_path), tester.el_group, 8);
+        aws_parallel_input_stream_new_from_file(allocator, file_path, tester.el_group, 8);
 
     struct aws_byte_buf read_buf;
     aws_byte_buf_init(&read_buf, allocator, s_parallel_stream_test->len);
@@ -185,7 +185,7 @@ TEST_CASE(parallel_read_stream_from_large_file_test) {
     struct aws_event_loop_group *el_group = aws_event_loop_group_new_default(allocator, 0, NULL);
 
     struct aws_parallel_input_stream *parallel_read_stream =
-        aws_parallel_input_stream_new_from_file(allocator, aws_byte_cursor_from_c_str(file_path), tester.el_group, 8);
+        aws_parallel_input_stream_new_from_file(allocator, file_path, tester.el_group, 8);
 
     {
         /* The whole file */

--- a/tests/s3_parallel_read_stream_test.c
+++ b/tests/s3_parallel_read_stream_test.c
@@ -155,6 +155,7 @@ TEST_CASE(parallel_read_stream_from_file_sanity_test) {
 
     struct aws_parallel_input_stream *parallel_read_stream =
         aws_parallel_input_stream_new_from_file(allocator, file_path, tester.el_group, 8);
+    ASSERT_NOT_NULL(parallel_read_stream);
 
     struct aws_byte_buf read_buf;
     aws_byte_buf_init(&read_buf, allocator, s_parallel_stream_test->len);
@@ -186,6 +187,7 @@ TEST_CASE(parallel_read_stream_from_large_file_test) {
 
     struct aws_parallel_input_stream *parallel_read_stream =
         aws_parallel_input_stream_new_from_file(allocator, file_path, tester.el_group, 8);
+    ASSERT_NOT_NULL(parallel_read_stream);
 
     {
         /* The whole file */


### PR DESCRIPTION
- A quick internal only impl of mmap wrapper.

Why mmap?
- We can avoid the possible FD limits with parallel read.
- We are not loading the file from disk to memory until needed
- It's "supposed" to be faster

Is mmap really better?
- ~I try to simply memcpy the mapped memory to another buffer, the OS seems to just skip loading the real data, I didn't find a way to easily ensure we load the data.~ It was a bug in my test program, now, I saw it's just the same as multi-thread fread for both cached or cold files.
- From the S3 tests, I am seeing slightly performance improvement with mmap and just fread.
```
mmap 
Run:1 Secs:12.621 Gb/s:20.4 Mb/s:20418.3 GiB/s:2.4 MiB/s:2434.1
Run:2 Secs:8.083 Gb/s:31.9 Mb/s:31880.9 GiB/s:3.7 MiB/s:3800.5
Run:3 Secs:8.686 Gb/s:29.7 Mb/s:29669.5 GiB/s:3.5 MiB/s:3536.9
Run:4 Secs:9.205 Gb/s:28.0 Mb/s:27995.9 GiB/s:3.3 MiB/s:3337.4
Run:5 Secs:8.259 Gb/s:31.2 Mb/s:31201.7 GiB/s:3.6 MiB/s:3719.5
Run:6 Secs:9.032 Gb/s:28.5 Mb/s:28532.3 GiB/s:3.3 MiB/s:3401.3
Run:7 Secs:9.140 Gb/s:28.2 Mb/s:28195.1 GiB/s:3.3 MiB/s:3361.1
Run:8 Secs:7.305 Gb/s:35.3 Mb/s:35278.1 GiB/s:4.1 MiB/s:4205.5
Run:9 Secs:9.986 Gb/s:25.8 Mb/s:25805.1 GiB/s:3.0 MiB/s:3076.2
Run:10 Secs:9.243 Gb/s:27.9 Mb/s:27881.3 GiB/s:3.2 MiB/s:3323.7

fread
Run:1 Secs:12.924 Gb/s:19.9 Mb/s:19940.2 GiB/s:2.3 MiB/s:2377.1
Run:2 Secs:9.986 Gb/s:25.8 Mb/s:25806.7 GiB/s:3.0 MiB/s:3076.4
Run:3 Secs:9.382 Gb/s:27.5 Mb/s:27466.3 GiB/s:3.2 MiB/s:3274.2
Run:4 Secs:10.024 Gb/s:25.7 Mb/s:25707.0 GiB/s:3.0 MiB/s:3064.5
Run:5 Secs:8.134 Gb/s:31.7 Mb/s:31683.2 GiB/s:3.7 MiB/s:3776.9
Run:6 Secs:9.643 Gb/s:26.7 Mb/s:26722.7 GiB/s:3.1 MiB/s:3185.6
Run:7 Secs:9.860 Gb/s:26.1 Mb/s:26136.3 GiB/s:3.0 MiB/s:3115.7
Run:8 Secs:9.008 Gb/s:28.6 Mb/s:28606.2 GiB/s:3.3 MiB/s:3410.1
Run:9 Secs:9.545 Gb/s:27.0 Mb/s:26998.6 GiB/s:3.1 MiB/s:3218.5
Run:10 Secs:8.926 Gb/s:28.9 Mb/s:28869.0 GiB/s:3.4 MiB/s:3441.5
```
- From tracing of the s3 tests, I saw the improvement from 7.5 secs to 6.8 secs, where our IO threads are doing intensive works. But, I would assume it's not really related to the difference between mmap and fread, as they are very likely not the bottle neck of the process.


How will mmap affect our memory usage?
- Needs to test and tracing. `mmap` supports to load the data on needed and we control how many data to read into memory. It "SHOULD" have no affect on our memory usage. However, I am not sure, I'll run some tracing and see the memory usage to make sure.
- Used `top` to track the memory usage, found that OS will load the data into memory and keep it until we unmap the memory. Fixed the memory issue by only map the needed part. The latest change has no effects on memory usage now.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
