### PR TITLE
Fix typo in aws_cached_signing_config_new

### DIFF
--- a/source/s3_util.c
+++ b/source/s3_util.c
@@ -205,7 +205,7 @@ struct aws_cached_signing_config_aws *aws_cached_signing_config_new(
 
     AWS_ASSERT(aws_byte_cursor_is_valid(&signing_config->signed_body_value));
 
-    if (signing_config->service.len > 0) {
+    if (signing_config->signed_body_value.len > 0) {
         cached_signing_config->signed_body_value =
             aws_string_new_from_cursor(allocator, &signing_config->signed_body_value);
 


### PR DESCRIPTION
*Issue #, if available:*
#357 
*Description of changes:*
Fixes a possible bad copy paste error where we check for `service.len` but assign `signed_body_value`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
