### PR TITLE
API to retrieve list of platform with recommended configuration

### DIFF
--- a/include/aws/s3/private/s3_platform_info.h
+++ b/include/aws/s3/private/s3_platform_info.h
@@ -49,7 +49,7 @@ const struct aws_s3_platform_info *aws_s3_get_platform_info_for_current_environm
  * Returns aws_array_list<aws_byte_cursor>. The caller is responsible for cleaning up the array list.
  */
 AWS_S3_API
-struct aws_array_list aws_s3_get_recommended_platforms_info(struct aws_s3_platform_info_loader *loader);
+struct aws_array_list aws_s3_get_recommended_platforms(struct aws_s3_platform_info_loader *loader);
 
 /**
  * Returns true if the current process is running on an Amazon EC2 instance powered by Nitro.

--- a/include/aws/s3/private/s3_platform_info.h
+++ b/include/aws/s3/private/s3_platform_info.h
@@ -44,6 +44,13 @@ AWS_S3_API
 const struct aws_s3_platform_info *aws_s3_get_platform_info_for_current_environment(
     struct aws_s3_platform_info_loader *loader);
 
+/*
+ * Retrieves a list of ec2 instance types that have a recommended configuration
+ * Returns aws_array_list<aws_byte_cursor>. It is the callers responsibility to clean up the array list.
+ */
+AWS_S3_API
+struct aws_array_list aws_s3_get_recommended_platforms_info(struct aws_s3_platform_info_loader *loader);
+
 /**
  * Returns true if the current process is running on an Amazon EC2 instance powered by Nitro.
  */

--- a/include/aws/s3/private/s3_platform_info.h
+++ b/include/aws/s3/private/s3_platform_info.h
@@ -45,7 +45,7 @@ const struct aws_s3_platform_info *aws_s3_get_platform_info_for_current_environm
     struct aws_s3_platform_info_loader *loader);
 
 /*
- * Retrieves a list of EC2 instance types with a recommended configuration.
+ * Retrieves a list of EC2 instance types with recommended configuration.
  * Returns aws_array_list<aws_byte_cursor>. The caller is responsible for cleaning up the array list.
  */
 AWS_S3_API

--- a/include/aws/s3/private/s3_platform_info.h
+++ b/include/aws/s3/private/s3_platform_info.h
@@ -45,8 +45,8 @@ const struct aws_s3_platform_info *aws_s3_get_platform_info_for_current_environm
     struct aws_s3_platform_info_loader *loader);
 
 /*
- * Retrieves a list of ec2 instance types that have a recommended configuration
- * Returns aws_array_list<aws_byte_cursor>. It is the callers responsibility to clean up the array list.
+ * Retrieves a list of EC2 instance types with a recommended configuration.
+ * Returns aws_array_list<aws_byte_cursor>. The caller is responsible for cleaning up the array list.
  */
 AWS_S3_API
 struct aws_array_list aws_s3_get_recommended_platforms_info(struct aws_s3_platform_info_loader *loader);

--- a/include/aws/s3/s3.h
+++ b/include/aws/s3/s3.h
@@ -114,8 +114,8 @@ AWS_S3_API
 const struct aws_s3_platform_info *aws_s3_get_current_platform_info(void);
 
 /*
- * Retrieves a list of ec2 instance types that have recommended configuration
- * Returns aws_array_list<aws_byte_cursor>. It is the callers responsibility to clean up the array list.
+ * Retrieves a list of EC2 instance types with a recommended configuration.
+ * Returns aws_array_list<aws_byte_cursor>. The caller is responsible for cleaning up the array list.
  */
 AWS_S3_API
 struct aws_array_list aws_s3_get_platforms_with_recommended_config(void);

--- a/include/aws/s3/s3.h
+++ b/include/aws/s3/s3.h
@@ -113,6 +113,13 @@ void aws_s3_library_clean_up(void);
 AWS_S3_API
 const struct aws_s3_platform_info *aws_s3_get_current_platform_info(void);
 
+/*
+ * Retrieves a list of ec2 instance types that have recommended configuration
+ * Returns aws_array_list<aws_byte_cursor>. It is the callers responsibility to clean up the array list.
+ */
+AWS_S3_API
+struct aws_array_list aws_s3_get_platforms_with_recommended_config(void);
+
 AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL
 

--- a/include/aws/s3/s3.h
+++ b/include/aws/s3/s3.h
@@ -114,7 +114,7 @@ AWS_S3_API
 const struct aws_s3_platform_info *aws_s3_get_current_platform_info(void);
 
 /*
- * Retrieves a list of EC2 instance types with a recommended configuration.
+ * Retrieves a list of EC2 instance types with recommended configuration.
  * Returns aws_array_list<aws_byte_cursor>. The caller is responsible for cleaning up the array list.
  */
 AWS_S3_API

--- a/source/s3.c
+++ b/source/s3.c
@@ -98,6 +98,10 @@ const struct aws_s3_platform_info *aws_s3_get_current_platform_info(void) {
     return aws_s3_get_platform_info_for_current_environment(s_loader);
 }
 
+struct aws_array_list aws_s3_get_platforms_with_recommended_config(void) {
+    return aws_s3_get_recommended_platforms_info(s_loader);
+}
+
 void aws_s3_library_clean_up(void) {
     if (!s_library_initialized) {
         return;

--- a/source/s3.c
+++ b/source/s3.c
@@ -99,7 +99,7 @@ const struct aws_s3_platform_info *aws_s3_get_current_platform_info(void) {
 }
 
 struct aws_array_list aws_s3_get_platforms_with_recommended_config(void) {
-    return aws_s3_get_recommended_platforms_info(s_loader);
+    return aws_s3_get_recommended_platforms(s_loader);
 }
 
 void aws_s3_library_clean_up(void) {

--- a/source/s3_platform_info.c
+++ b/source/s3_platform_info.c
@@ -569,7 +569,7 @@ const struct aws_s3_platform_info *aws_s3_get_platform_info_for_current_environm
     return &loader->lock_data.current_env_platform_info;
 }
 
-struct aws_array_list aws_s3_get_recommended_platforms_info(struct aws_s3_platform_info_loader *loader) {
+struct aws_array_list aws_s3_get_recommended_platforms(struct aws_s3_platform_info_loader *loader) {
     struct aws_array_list array_list;
     aws_mutex_lock(&loader->lock_data.lock);
     aws_array_list_init_dynamic(&array_list, loader->allocator, 5, sizeof(struct aws_byte_cursor));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,6 +189,7 @@ add_test_case(test_add_user_agent_header)
 
 add_test_case(test_get_existing_platform_info)
 add_test_case(test_get_nonexistent_platform_info)
+add_test_case(test_get_platforms_with_recommended_config)
 add_net_test_case(load_platform_info_from_global_state_sanity_test)
 
 add_net_test_case(sha1_nist_test_case_1)

--- a/tests/s3_platform_info_test.c
+++ b/tests/s3_platform_info_test.c
@@ -105,6 +105,11 @@ static int s_test_get_platforms_with_recommended_config(struct aws_allocator *al
 
     struct aws_array_list recommended_platform_list = aws_s3_get_platforms_with_recommended_config();
     ASSERT_TRUE(aws_array_list_length(&recommended_platform_list) > 0);
+    for (size_t i = 0; i < aws_array_list_length(&recommended_platform_list); ++i) {
+        struct aws_byte_cursor *cursor;
+        aws_array_list_get_at_ptr(&recommended_platform_list, (void **)&cursor, i);
+        ASSERT_TRUE(cursor->len > 0);
+    }
     aws_array_list_clean_up(&recommended_platform_list);
     aws_s3_library_clean_up();
     return AWS_OP_SUCCESS;

--- a/tests/s3_platform_info_test.c
+++ b/tests/s3_platform_info_test.c
@@ -97,3 +97,17 @@ static int s_load_platform_info_from_global_state_sanity_test(struct aws_allocat
 }
 
 AWS_TEST_CASE(load_platform_info_from_global_state_sanity_test, s_load_platform_info_from_global_state_sanity_test)
+
+static int s_test_get_platforms_with_recommended_config(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    aws_s3_library_init(allocator);
+
+    struct aws_array_list recommended_platform_list = aws_s3_get_platforms_with_recommended_config();
+    ASSERT_TRUE(aws_array_list_length(&recommended_platform_list) > 0);
+    aws_array_list_clean_up(&recommended_platform_list);
+    aws_s3_library_clean_up();
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(test_get_platforms_with_recommended_config, s_test_get_platforms_with_recommended_config)

--- a/tests/s3_platform_info_test.c
+++ b/tests/s3_platform_info_test.c
@@ -106,9 +106,9 @@ static int s_test_get_platforms_with_recommended_config(struct aws_allocator *al
     struct aws_array_list recommended_platform_list = aws_s3_get_platforms_with_recommended_config();
     ASSERT_TRUE(aws_array_list_length(&recommended_platform_list) > 0);
     for (size_t i = 0; i < aws_array_list_length(&recommended_platform_list); ++i) {
-        struct aws_byte_cursor *cursor;
-        aws_array_list_get_at_ptr(&recommended_platform_list, (void **)&cursor, i);
-        ASSERT_TRUE(cursor->len > 0);
+        struct aws_byte_cursor cursor;
+        aws_array_list_get_at(&recommended_platform_list, &cursor, i);
+        ASSERT_TRUE(cursor.len > 0);
     }
     aws_array_list_clean_up(&recommended_platform_list);
     aws_s3_library_clean_up();


### PR DESCRIPTION
*Description of changes:*
- Adds a new API which returns a list of ec2 instance types with recommended configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
