### PR TITLE
Use uint64_t for memory limit and cap it to SIZE_MAX

### DIFF
--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -421,7 +421,7 @@ struct aws_s3_client_config {
     /* Throughput target in gigabits per second (Gbps) that we are trying to reach. */
     double throughput_target_gbps;
 
-    /* How much memory can we use. */
+    /* How much memory can we use. This will be capped to SIZE_MAX */
     uint64_t memory_limit_in_bytes;
 
     /* Retry strategy to use. If NULL, a default retry strategy will be used. */

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -422,7 +422,7 @@ struct aws_s3_client_config {
     double throughput_target_gbps;
 
     /* How much memory can we use. */
-    size_t memory_limit_in_bytes;
+    uint64_t memory_limit_in_bytes;
 
     /* Retry strategy to use. If NULL, a default retry strategy will be used. */
     struct aws_retry_strategy *retry_strategy;

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -342,7 +342,12 @@ struct aws_s3_client *aws_s3_client_new(
         }
 #endif
     } else {
-        mem_limit = client_config->memory_limit_in_bytes;
+        // cap memory limit to SIZE_MAX
+        if (client_config->memory_limit_in_bytes > SIZE_MAX) {
+            mem_limit = SIZE_MAX;
+        } else {
+            mem_limit = (size_t)client_config->memory_limit_in_bytes;
+        }
     }
 
     size_t part_size = s_default_part_size;


### PR DESCRIPTION
*Description of changes:*
- We want people to be able to specify memory limit > 4Gb and still be able to deploy same application to both 32bit and 64bit systems.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
