### PR TITLE
Stop limiting num-connections based on num-known-IPs (Improve S3-Express performance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The AWS-C-S3 library is an asynchronous AWS S3 client focused on maximizing thro
 ### Key features:
 - **Automatic Request Splitting**: Improves throughput by automatically splitting the request into part-sized chunks and performing parallel uploads/downloads of these chunks over multiple connections. There's a cap on the throughput of single S3 connection, the only way to go faster is multiple parallel connections.
 - **Automatic Retries**: Increases resilience by retrying individual failed chunks of a file transfer, eliminating the need to restart transfers from scratch after an intermittent error.
-- **DNS Load Balancing**: DNS resolver continuously harvests Amazon S3 IP addresses. When load is spread across the S3 fleet, overall throughput is better than if all connections were hammering the same IP simultaneously.
+- **DNS Load Balancing**: DNS resolver continuously harvests Amazon S3 IP addresses. When load is spread across the S3 fleet, overall throughput more reliable than if all connections are going to a single IP.
 - **Advanced Network Management**: The client incorporates automatic request parallelization, effective timeouts and retries, and efficient connection reuse. This approach helps to maximize throughput and network utilization, and to avoid network overloads.
 - **Thread Pools and Async I/O**: Avoids bottlenecks associated with single-thread processing.
 - **Parallel Reads**: When uploading a large file from disk, reads from multiple parts of the file in parallel. This is faster than reading the file sequentially from beginning to end.

--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -242,8 +242,8 @@ struct aws_s3_client {
     /* Throughput target in Gbps that we are trying to reach. */
     const double throughput_target_gbps;
 
-    /* The calculated ideal number of VIP's based on throughput target and throughput per vip. */
-    const uint32_t ideal_vip_count;
+    /* The calculated ideal number of HTTP connections, based on throughput target and throughput per connection. */
+    const uint32_t ideal_connection_count;
 
     /**
      * For multi-part upload, content-md5 will be calculated if the AWS_MR_CONTENT_MD5_ENABLED is specified
@@ -484,10 +484,10 @@ struct aws_s3_endpoint *aws_s3_endpoint_acquire(struct aws_s3_endpoint *endpoint
 void aws_s3_endpoint_release(struct aws_s3_endpoint *endpoint);
 
 AWS_S3_API
-extern const uint32_t g_max_num_connections_per_vip;
+extern const uint32_t g_min_num_connections;
 
 AWS_S3_API
-extern const uint32_t g_num_conns_per_vip_meta_request_look_up[];
+extern const uint32_t g_max_num_connections;
 
 AWS_S3_API
 extern const size_t g_expect_timeout_offset_ms;

--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -487,9 +487,6 @@ AWS_S3_API
 extern const uint32_t g_min_num_connections;
 
 AWS_S3_API
-extern const uint32_t g_max_num_connections;
-
-AWS_S3_API
 extern const size_t g_expect_timeout_offset_ms;
 
 AWS_S3_API

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -64,7 +64,7 @@ static const uint32_t s_max_requests_multiplier = 4;
  * TODO: Improve this algorithm (expect higher throughput for S3 Express,
  * expect lower throughput for small objects, etc)
  */
-static const double s_throughput_per_connection_gbps = 100.0 / 160;
+static const double s_throughput_per_connection_gbps = 100.0 / 250;
 
 /* After throughput math, clamp the min/max number of connections */
 const uint32_t g_min_num_connections = 10;     /* Magic value based on: 10 was old behavior */

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -66,7 +66,7 @@ static const uint32_t s_max_requests_multiplier = 4;
 static const double s_throughput_per_connection_gbps = 100.0 / 250;
 
 /* After throughput math, clamp the min/max number of connections */
-const uint32_t g_min_num_connections = 10;     /* Magic value based on: 10 was old behavior */
+const uint32_t g_min_num_connections = 10; /* Magic value based on: 10 was old behavior */
 
 /**
  * Default part size is 8 MiB to reach the best performance from the experiments we had.

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -55,11 +55,10 @@ static const enum aws_log_level s_log_level_client_stats = AWS_LL_INFO;
 static const uint32_t s_max_requests_multiplier = 4;
 
 /* This is used to determine the ideal number of HTTP connections. Algorithm is roughly:
- * ideal-num-connections = throughput-target-gpbs / s_throughput_per_connection_gbps
+ * num-connections-max = throughput-target-gbps / s_throughput_per_connection_gbps
  *
- * Magic value based on:
- * We found 160 connections gave best performance for 30 GiB download
- * (3840 8MiB parts) on 100Gbps c5n.18xlarge.
+ * Magic value based on: match results of the previous algorithm,
+ * where throughput-target-gpbs of 100 resulted in 250 connections.
  *
  * TODO: Improve this algorithm (expect higher throughput for S3 Express,
  * expect lower throughput for small objects, etc)
@@ -68,7 +67,6 @@ static const double s_throughput_per_connection_gbps = 100.0 / 250;
 
 /* After throughput math, clamp the min/max number of connections */
 const uint32_t g_min_num_connections = 10;     /* Magic value based on: 10 was old behavior */
-const uint32_t g_max_num_connections = 100000; /* Magic value based on: 100000 is pretty big */
 
 /**
  * Default part size is 8 MiB to reach the best performance from the experiments we had.
@@ -525,7 +523,7 @@ struct aws_s3_client *aws_s3_client_new(
         /* round up and clamp */
         ideal_connection_count_double = ceil(ideal_connection_count_double);
         ideal_connection_count_double = aws_max_double(g_min_num_connections, ideal_connection_count_double);
-        ideal_connection_count_double = aws_min_double(g_max_num_connections, ideal_connection_count_double);
+        ideal_connection_count_double = aws_min_double(UINT32_MAX, ideal_connection_count_double);
         *(uint32_t *)&client->ideal_connection_count = (uint32_t)ideal_connection_count_double;
     }
 


### PR DESCRIPTION
**Issue:**
Disappointing S3-Express performance.

**Description of changes:**
Stop limiting num-connections based on num-known-IPs.

**Diagnosing the issue:**
We found that num-connections was never getting very high, because [num-connections scales based on the num-known-IPs](https://github.com/awslabs/aws-c-s3/blob/593c2ab24608d3e78708d51657be22f6ab99cb50/source/s3_client.c#L179). S3-Express endpoints have very few IPs, so their num-connections weren't scaling very high.

The algorithm was adding 10 connections per known-IP. On a 100Gb/s machine, this maxed out at 250 connections once 25 IPs were known. But S3-Express endpoints only have 4 unique IPs, so they never got higher than 40 connections.

This algorithm was written back when S3 returned 1 IP per DNS query. The intention was to throttle connections until more IPs were known, in order to spread load among S3's server fleet. However, as of Aug 2023 [S3 provides multiple IPs per DNS query](https://aws.amazon.com/about-aws/whats-new/2023/08/amazon-s3-multivalue-answer-response-dns-queries/). So now, we can scale up to max connections after the first DNS query and still be spreading load.

We also believed that spreading load was a key to good performance. But I found that spreading the load didn't have much impact on performance (at least now, in 2024, on the 100Gb/s machine I was using). Tests where I hard-coded a single IP and hit it with max-connections didn't differ much from tests where the load was spread among 8 IPs or 100 IPs.

I want to get this change out quickly and help S3-Express, so I picked magic numbers where the num-connections math ends up with the same result as the old algorithm. Normal S3 performance is mildly improved (max-connections is reached immediately, instead of scaling up over 30sec as it finds more IPs). S3 Express performance is MUCH improved.

**Future Work:**
Improve this algorithm further:
- expect higher throughput on connections to S3 Express
- expect lower throughput on connections transferring small objects
- dynamic scaling without a bunch of magic numbers ??? (sounds cool, but I don't have any ideas how this would work yet)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
