### PR TITLE
Report `aws_s3_meta_request_result::error_response_body` for server-side errors

### DIFF
--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -759,10 +759,8 @@ struct aws_s3_meta_request_options {
  * If error_code is AWS_ERROR_SUCCESS, then response_status will match the response_status passed earlier by the header
  * callback and error_response_headers and error_response_body will be NULL.
  *
- * If error_code is equal to AWS_ERROR_S3_INVALID_RESPONSE_STATUS, then error_response_headers, error_response_body, and
- * response_status will be populated by the failed request.
- *
- * For all other error codes, response_status will be 0, and the error_response variables will be NULL.
+ * Fields error_response_headers, error_response_body, response_status will be provided for all server-side failures, i.e.
+ * when error_code is not in {AWS_ERROR_S3_CANCELED, AWS_ERROR_S3_PAUSED, AWS_ERROR_INVALID_STATE}.
  */
 struct aws_s3_meta_request_result {
 

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -401,9 +401,7 @@ void aws_s3_meta_request_set_fail_synced(
 
     meta_request->synced_data.finish_result_set = true;
 
-    if ((error_code == AWS_ERROR_S3_INVALID_RESPONSE_STATUS || error_code == AWS_ERROR_S3_NON_RECOVERABLE_ASYNC_ERROR ||
-         error_code == AWS_ERROR_S3_OBJECT_MODIFIED) &&
-        failed_request != NULL) {
+    if (failed_request != NULL) {
         aws_s3_meta_request_result_setup(
             meta_request,
             &meta_request->synced_data.finish_result,
@@ -411,7 +409,8 @@ void aws_s3_meta_request_set_fail_synced(
             failed_request->send_data.response_status,
             error_code);
     } else {
-        AWS_ASSERT(error_code != AWS_ERROR_S3_INVALID_RESPONSE_STATUS);
+        /* Request must be present for all server-side failures */
+        AWS_ASSERT(error_code == AWS_ERROR_S3_CANCELED || error_code == AWS_ERROR_S3_PAUSED || error_code == AWS_ERROR_INVALID_STATE);
 
         aws_s3_meta_request_result_setup(meta_request, &meta_request->synced_data.finish_result, NULL, 0, error_code);
     }


### PR DESCRIPTION
*Issue #, if available:* No

*Description of changes:*
Today the `response_status` / `error_response_body` of the last failed request are only reported in `finish_callback` for `AWS_ERROR_S3_INVALID_RESPONSE_STATUS` error code . In order to have access to that information in case of, e.g. `AWS_ERROR_S3_SLOW_DOWN`, we need to do this change. 

The alternatives - `telemetry_callback` and `body_callback` - are not that usable to achieve that. Specifically to record the body of the last failed S3 request of the meta-request. Is `body_callback` even invoked in case of a failure? 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
