### PR TITLE
Make options more const

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.59
+  BUILDER_VERSION: v0.9.61
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-s3

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -756,7 +756,7 @@ struct aws_s3_meta_request_options {
      * Note: If PutObject request specifies a checksum algorithm, client will calculate checksums while skipping parts
      * from the buffer and compare them them to previously uploaded part checksums.
      */
-    const struct aws_s3_meta_request_resume_token *resume_token;
+    struct aws_s3_meta_request_resume_token *resume_token;
 
     /*
      * Optional.

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -369,8 +369,9 @@ struct aws_s3_client_config {
     enum aws_s3_meta_request_tls_mode tls_mode;
 
     /* TLS Options to be used for each connection, if tls_mode is ENABLED. When compiling with BYO_CRYPTO, and tls_mode
-     * is ENABLED, this is required. Otherwise, this is optional. */
-    struct aws_tls_connection_options *tls_connection_options;
+     * is ENABLED, this is required. Otherwise, this is optional.
+     */
+    const struct aws_tls_connection_options *tls_connection_options;
 
     /**
      * Required.
@@ -387,7 +388,7 @@ struct aws_s3_client_config {
      *
      * TODO: deprecate this structure from auth, introduce a new S3 specific one.
      */
-    struct aws_signing_config_aws *signing_config;
+    const struct aws_signing_config_aws *signing_config;
 
     /**
      * Optional.
@@ -445,7 +446,7 @@ struct aws_s3_client_config {
      * If the connection_type is AWS_HPCT_HTTP_LEGACY, it will be converted to AWS_HPCT_HTTP_TUNNEL if tls_mode is
      * ENABLED. Otherwise, it will be converted to AWS_HPCT_HTTP_FORWARD.
      */
-    struct aws_http_proxy_options *proxy_options;
+    const struct aws_http_proxy_options *proxy_options;
 
     /**
      * Optional.
@@ -454,7 +455,7 @@ struct aws_s3_client_config {
      * configuration from environment.
      * Only works when proxy_options is not set. If both are set, configuration from proxy_options is used.
      */
-    struct proxy_env_var_settings *proxy_ev_settings;
+    const struct proxy_env_var_settings *proxy_ev_settings;
 
     /**
      * Optional.
@@ -466,7 +467,7 @@ struct aws_s3_client_config {
      * Optional.
      * Set keepalive to periodically transmit messages for detecting a disconnected peer.
      */
-    struct aws_s3_tcp_keep_alive_options *tcp_keep_alive_options;
+    const struct aws_s3_tcp_keep_alive_options *tcp_keep_alive_options;
 
     /**
      * Optional.
@@ -474,7 +475,7 @@ struct aws_s3_client_config {
      * If the transfer speed falls below the specified minimum_throughput_bytes_per_second, the operation is aborted.
      * If set to NULL, default values are used.
      */
-    struct aws_http_connection_monitoring_options *monitoring_options;
+    const struct aws_http_connection_monitoring_options *monitoring_options;
 
     /**
      * Enable backpressure and prevent response data from downloading faster than you can handle it.
@@ -558,7 +559,7 @@ struct aws_s3_checksum_config {
      *
      * If the response checksum was validated by client, the result will indicate which algorithm was picked.
      */
-    struct aws_array_list *validate_checksum_algorithms;
+    const struct aws_array_list *validate_checksum_algorithms;
 };
 
 /**
@@ -746,7 +747,7 @@ struct aws_s3_meta_request_options {
      * - Both Host and Endpoint is set - Host header must match Authority of
      *   Endpoint uri. Port and Scheme from endpoint is used.
      */
-    struct aws_uri *endpoint;
+    const struct aws_uri *endpoint;
 
     /**
      * Optional.
@@ -755,7 +756,7 @@ struct aws_s3_meta_request_options {
      * Note: If PutObject request specifies a checksum algorithm, client will calculate checksums while skipping parts
      * from the buffer and compare them them to previously uploaded part checksums.
      */
-    struct aws_s3_meta_request_resume_token *resume_token;
+    const struct aws_s3_meta_request_resume_token *resume_token;
 
     /*
      * Optional.
@@ -764,7 +765,7 @@ struct aws_s3_meta_request_options {
      * Set this hint to help the S3 client choose the best strategy for this particular file.
      * This is just used as an estimate, so it's okay to provide an approximate value if the exact size is unknown.
      */
-    uint64_t *object_size_hint;
+    const uint64_t *object_size_hint;
 };
 
 /* Result details of a meta request.

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -475,7 +475,7 @@ int aws_s3_tester_bind_client(struct aws_s3_tester *tester, struct aws_s3_client
         config->region = g_test_s3_region;
     } else {
         if (config->signing_config) {
-            (struct aws_signing_config_aws *)(config->signing_config)->region = config->region;
+            ((struct aws_signing_config_aws *)config->signing_config)->region = config->region;
         }
     }
     if (!config->signing_config) {

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -475,7 +475,7 @@ int aws_s3_tester_bind_client(struct aws_s3_tester *tester, struct aws_s3_client
         config->region = g_test_s3_region;
     } else {
         if (config->signing_config) {
-            config->signing_config->region = config->region;
+            (struct aws_signing_config_aws *)(config->signing_config)->region = config->region;
         }
     }
     if (!config->signing_config) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
make everything passed in by pointer in options const as we always copy the underlying data.
everything that is ref counted is kept as is, since refcounted functions dont play with const ptrs nicely


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
