### PR TITLE
Fix MemoryLimit primary_allocated stat

### DIFF
--- a/source/s3_buffer_pool.c
+++ b/source/s3_buffer_pool.c
@@ -232,6 +232,7 @@ void s_buffer_pool_trim_synced(struct aws_s3_buffer_pool *buffer_pool) {
         aws_array_list_get_at_ptr(&buffer_pool->blocks, (void **)&block, i);
 
         if (block->alloc_bit_mask == 0) {
+            buffer_pool->primary_allocated -= block->block_size;
             aws_mem_release(buffer_pool->base_allocator, block->block_ptr);
             aws_array_list_erase(&buffer_pool->blocks, i);
             /* do not increment since we just released element */

--- a/tests/s3_buffer_pool_tests.c
+++ b/tests/s3_buffer_pool_tests.c
@@ -158,6 +158,7 @@ static int s_test_s3_buffer_pool_trim(struct aws_allocator *allocator, void *ctx
     struct aws_s3_buffer_pool_usage_stats stats_after = aws_s3_buffer_pool_get_usage(buffer_pool);
 
     ASSERT_TRUE(stats_before.primary_num_blocks > stats_after.primary_num_blocks);
+    ASSERT_TRUE(stats_before.primary_allocated > stats_after.primary_allocated);
 
     for (size_t i = 20; i < 40; ++i) {
         aws_s3_buffer_pool_release_ticket(buffer_pool, tickets[i]);


### PR DESCRIPTION
*Description of changes:*
- We never decrement the primary_used stat, which leads to incorrect reporting of an ever-increasing number.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
