### PR TITLE
[meta request]: assign shutdown_callback inside critical region

### DIFF
--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -1126,6 +1126,11 @@ struct aws_s3_meta_request *aws_s3_client_make_meta_request(
         }
 
         meta_request->endpoint = endpoint;
+        /**
+         * shutdown_callback must be the last thing that gets set on the meta_request so that we don’t return NULL and
+         * trigger the shutdown_callback.
+         */
+        meta_request->shutdown_callback = options->shutdown_callback;
 
         s_s3_client_push_meta_request_synced(client, meta_request);
         s_s3_client_schedule_process_work_synced(client);
@@ -1146,11 +1151,6 @@ struct aws_s3_meta_request *aws_s3_client_make_meta_request(
         meta_request = aws_s3_meta_request_release(meta_request);
     } else {
         AWS_LOGF_INFO(AWS_LS_S3_CLIENT, "id=%p: Created meta request %p", (void *)client, (void *)meta_request);
-        /**
-         * shutdown_callback must be the last thing that gets set on the meta_request so that we don’t return NULL and
-         * trigger the shutdown_callback.
-         */
-        meta_request->shutdown_callback = options->shutdown_callback;
     }
 
     return meta_request;


### PR DESCRIPTION
The `shutdown_callback` was assigned outside of the critical region, resulting in a race condition.

Move the assignment inside the critical region, right to the end (to ensure that the callback is `NULL` on error).

Resolves #469.
