### PR TITLE
Remove Extra Platform Info That Is Not Used

### DIFF
--- a/include/aws/s3/s3.h
+++ b/include/aws/s3/s3.h
@@ -65,16 +65,6 @@ enum aws_s3_subject {
 
 struct aws_s3_platform_info;
 
-struct aws_s3_cpu_group_info {
-    /* group index, this usually refers to a particular numa node */
-    uint16_t cpu_group;
-    /* array of network devices on this node */
-    struct aws_byte_cursor *nic_name_array;
-    /* length of network devices array */
-    size_t nic_name_array_length;
-    size_t cpus_in_group;
-};
-
 #ifdef _MSC_VER
 #    pragma warning(push)
 #    pragma warning(disable : 4626) /* assignment operator was implicitly defined as deleted */
@@ -86,11 +76,6 @@ struct aws_s3_platform_info {
     struct aws_byte_cursor instance_type;
     /* max throughput for this instance type, in gigabits per second */
     double max_throughput_gbps;
-    /* array of cpu group info. This will always have at least one entry. */
-    struct aws_s3_cpu_group_info *cpu_group_info_array;
-    /* length of cpu group info array */
-    size_t cpu_group_info_array_length;
-
     /* The current build of this library specifically knows an optimal configuration for this
      * platform */
     bool has_recommended_configuration;

--- a/samples/s3/s3-platform_info.c
+++ b/samples/s3/s3-platform_info.c
@@ -65,32 +65,5 @@ int s3_compute_platform_info_main(int argc, char *argv[], const char *command_na
     printf("\t'instance_type': '" PRInSTR "',\n", AWS_BYTE_CURSOR_PRI(platform_info->instance_type));
     printf("\t'max_throughput_gbps': %d,\n", (int)platform_info->max_throughput_gbps);
     printf("\t'has_recommended_configuration': %s,\n", platform_info->has_recommended_configuration ? "true" : "false");
-
-    printf("\t'cpu_groups': [\n");
-
-    for (size_t i = 0; i < platform_info->cpu_group_info_array_length; ++i) {
-        printf("\t{\n");
-        printf("\t\t'cpu_group_index': %d,\n", (int)platform_info->cpu_group_info_array[i].cpu_group);
-        printf("\t\t'cpus_in_group': %d,\n", (int)platform_info->cpu_group_info_array[i].cpus_in_group);
-        printf("\t\t'usable_network_devices': [\n");
-
-        for (size_t j = 0; j < platform_info->cpu_group_info_array[i].nic_name_array_length; j++) {
-            printf(
-                "\t\t\t'" PRInSTR "'", AWS_BYTE_CURSOR_PRI(platform_info->cpu_group_info_array[i].nic_name_array[j]));
-            if (j < platform_info->cpu_group_info_array[i].nic_name_array_length - 1) {
-                printf(",");
-            }
-            printf("\n");
-        }
-        printf("\t\t]\n");
-        printf("\t}");
-        if (i < platform_info->cpu_group_info_array_length - 1) {
-            printf(",");
-        }
-        printf("\n");
-    }
-    printf("\t]\n");
-    printf("}\n");
-
     return 0;
 }

--- a/source/s3_platform_info.c
+++ b/source/s3_platform_info.c
@@ -15,28 +15,9 @@
 #include <aws/s3/private/s3_platform_info.h>
 
 /**** Configuration info for the c5n.18xlarge *****/
-static struct aws_byte_cursor s_c5n_nic_array[] = {AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth0")};
-
-static struct aws_s3_cpu_group_info s_c5n_18xlarge_cpu_group_info_array[] = {
-    {
-        .cpu_group = 0u,
-        .nic_name_array = s_c5n_nic_array,
-        .nic_name_array_length = AWS_ARRAY_SIZE(s_c5n_nic_array),
-        .cpus_in_group = 36,
-    },
-    {
-        .cpu_group = 1u,
-        .nic_name_array = NULL,
-        .nic_name_array_length = 0u,
-        .cpus_in_group = 36,
-    },
-};
-
 static struct aws_s3_platform_info s_c5n_18xlarge_platform_info = {
     .instance_type = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("c5n.18xlarge"),
     .max_throughput_gbps = 100u,
-    .cpu_group_info_array = s_c5n_18xlarge_cpu_group_info_array,
-    .cpu_group_info_array_length = AWS_ARRAY_SIZE(s_c5n_18xlarge_cpu_group_info_array),
     /** not yet **/
     .has_recommended_configuration = false,
 };
@@ -44,8 +25,6 @@ static struct aws_s3_platform_info s_c5n_18xlarge_platform_info = {
 static struct aws_s3_platform_info s_c5n_metal_platform_info = {
     .instance_type = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("c5n.metal"),
     .max_throughput_gbps = 100u,
-    .cpu_group_info_array = s_c5n_18xlarge_cpu_group_info_array,
-    .cpu_group_info_array_length = AWS_ARRAY_SIZE(s_c5n_18xlarge_cpu_group_info_array),
     /** not yet **/
     .has_recommended_configuration = false,
 };
@@ -53,20 +32,9 @@ static struct aws_s3_platform_info s_c5n_metal_platform_info = {
 /****** End c5n.18xlarge *****/
 
 /****** Begin c5n.large ******/
-static struct aws_s3_cpu_group_info s_c5n_9xlarge_cpu_group_info_array[] = {
-    {
-        .cpu_group = 0u,
-        .nic_name_array = s_c5n_nic_array,
-        .nic_name_array_length = AWS_ARRAY_SIZE(s_c5n_nic_array),
-        .cpus_in_group = 36,
-    },
-};
-
 static struct aws_s3_platform_info s_c5n_9xlarge_platform_info = {
     .instance_type = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("c5n.9xlarge"),
     .max_throughput_gbps = 50u,
-    .cpu_group_info_array = s_c5n_9xlarge_cpu_group_info_array,
-    .cpu_group_info_array_length = AWS_ARRAY_SIZE(s_c5n_9xlarge_cpu_group_info_array),
     /** not yet **/
     .has_recommended_configuration = false,
 };
@@ -74,44 +42,15 @@ static struct aws_s3_platform_info s_c5n_9xlarge_platform_info = {
 /****** End c5n.9large *****/
 
 /***** Begin p4d.24xlarge and p4de.24xlarge ****/
-static struct aws_byte_cursor s_p4d_socket1_array[] = {
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth0"),
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth1"),
-};
-
-static struct aws_byte_cursor s_p4d_socket2_array[] = {
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth2"),
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth3"),
-};
-
-static struct aws_s3_cpu_group_info s_p4d_cpu_group_info_array[] = {
-    {
-        .cpu_group = 0u,
-        .nic_name_array = s_p4d_socket1_array,
-        .nic_name_array_length = AWS_ARRAY_SIZE(s_p4d_socket1_array),
-        .cpus_in_group = 48,
-    },
-    {
-        .cpu_group = 1u,
-        .nic_name_array = s_p4d_socket2_array,
-        .nic_name_array_length = AWS_ARRAY_SIZE(s_p4d_socket1_array),
-        .cpus_in_group = 48,
-    },
-};
-
 static struct aws_s3_platform_info s_p4d_platform_info = {
     .instance_type = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("p4d.24xlarge"),
     .max_throughput_gbps = 400u,
-    .cpu_group_info_array = s_p4d_cpu_group_info_array,
-    .cpu_group_info_array_length = AWS_ARRAY_SIZE(s_p4d_cpu_group_info_array),
     .has_recommended_configuration = true,
 };
 
 static struct aws_s3_platform_info s_p4de_platform_info = {
     .instance_type = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("p4de.24xlarge"),
     .max_throughput_gbps = 400u,
-    .cpu_group_info_array = s_p4d_cpu_group_info_array,
-    .cpu_group_info_array_length = AWS_ARRAY_SIZE(s_p4d_cpu_group_info_array),
     .has_recommended_configuration = true,
 };
 
@@ -127,113 +66,25 @@ static struct aws_s3_platform_info s_p4de_platform_info = {
  * per node. However, practically, due to the topology of this instance
  * as far as this client is concerned, there are two NICs per node, similar
  * to the p4d. The rest is for other things on the machine to use. */
-
-struct aws_byte_cursor s_p5_socket1_array[] = {
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth0"),
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth1"),
-};
-
-static struct aws_byte_cursor s_p5_socket2_array[] = {
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth2"),
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth3"),
-};
-
-static struct aws_s3_cpu_group_info s_p5_cpu_group_info_array[] = {
-    {
-        .cpu_group = 0u,
-        .nic_name_array = s_p5_socket1_array,
-        .nic_name_array_length = AWS_ARRAY_SIZE(s_p5_socket1_array),
-        .cpus_in_group = 96,
-    },
-    {
-        .cpu_group = 1u,
-        .nic_name_array = s_p5_socket2_array,
-        .nic_name_array_length = AWS_ARRAY_SIZE(s_p5_socket2_array),
-        .cpus_in_group = 96,
-    },
-};
-
 struct aws_s3_platform_info s_p5_platform_info = {
     .instance_type = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("p5.48xlarge"),
-    .max_throughput_gbps = 400u,
-    .cpu_group_info_array = s_p5_cpu_group_info_array,
-    .cpu_group_info_array_length = AWS_ARRAY_SIZE(s_p5_cpu_group_info_array),
+    .max_throughput_gbps = 400U,
     .has_recommended_configuration = true,
 };
-
 /***** End p5.48xlarge *****/
 
 /**** Begin trn1_32_large *****/
-struct aws_byte_cursor s_trn1_n_socket1_array[] = {
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth0"),
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth1"),
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth2"),
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth3"),
-
-};
-
-static struct aws_byte_cursor s_trn1_n_socket2_array[] = {
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth4"),
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth5"),
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth6"),
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth7"),
-};
-
-static struct aws_s3_cpu_group_info s_trn1_n_cpu_group_info_array[] = {
-    {
-        .cpu_group = 0u,
-        .nic_name_array = s_trn1_n_socket1_array,
-        .nic_name_array_length = AWS_ARRAY_SIZE(s_trn1_n_socket1_array),
-        .cpus_in_group = 64,
-    },
-    {
-        .cpu_group = 1u,
-        .nic_name_array = s_trn1_n_socket2_array,
-        .nic_name_array_length = AWS_ARRAY_SIZE(s_trn1_n_socket2_array),
-        .cpus_in_group = 64,
-    },
-};
-
 static struct aws_s3_platform_info s_trn1_n_platform_info = {
     .instance_type = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("trn1n.32xlarge"),
     /* not all of the advertised 1600 Gbps bandwidth can be hit from the cpu in user-space */
     .max_throughput_gbps = 800,
-    .cpu_group_info_array = s_trn1_n_cpu_group_info_array,
-    .cpu_group_info_array_length = AWS_ARRAY_SIZE(s_trn1_n_cpu_group_info_array),
     .has_recommended_configuration = true,
-};
-
-struct aws_byte_cursor s_trn1_socket1_array[] = {
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth0"),
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth1"),
-};
-
-static struct aws_byte_cursor s_trn1_socket2_array[] = {
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth3"),
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("eth4"),
-};
-
-static struct aws_s3_cpu_group_info s_trn1_cpu_group_info_array[] = {
-    {
-        .cpu_group = 0u,
-        .nic_name_array = s_trn1_socket1_array,
-        .nic_name_array_length = AWS_ARRAY_SIZE(s_trn1_socket1_array),
-        .cpus_in_group = 64,
-    },
-    {
-        .cpu_group = 1u,
-        .nic_name_array = s_trn1_socket2_array,
-        .nic_name_array_length = AWS_ARRAY_SIZE(s_trn1_socket2_array),
-        .cpus_in_group = 64,
-    },
 };
 
 static struct aws_s3_platform_info s_trn1_platform_info = {
     .instance_type = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("trn1.32xlarge"),
     /* not all of the advertised 800 Gbps bandwidth can be hit from the cpu in user-space */
     .max_throughput_gbps = 600,
-    .cpu_group_info_array = s_trn1_cpu_group_info_array,
-    .cpu_group_info_array_length = AWS_ARRAY_SIZE(s_trn1_cpu_group_info_array),
     .has_recommended_configuration = true,
 };
 


### PR DESCRIPTION
*Description of changes:*
- Remove cpu_group and numa_nodes information for now. These were added for a future optimization where we would auto-configure the best possible settings based on NUMA nodes, but we are not using this functionality yet. As a wise man once said
<img width="646" alt="image" src="https://github.com/user-attachments/assets/799f8c3c-e005-47f0-aca6-b46f32826ae0" />

Remove this until needed. 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
