### PR TITLE
[s3_client]: retry on failed TLS negotiation

### DIFF
--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -2108,12 +2108,11 @@ static void s_s3_client_on_acquire_http_connection(
             error_code,
             aws_error_str(error_code));
 
-        if (error_code == AWS_IO_DNS_INVALID_NAME || error_code == AWS_IO_TLS_ERROR_NEGOTIATION_FAILURE ||
+        if (error_code == AWS_IO_DNS_INVALID_NAME ||
             error_code == AWS_ERROR_PLATFORM_NOT_SUPPORTED || error_code == AWS_IO_SOCKET_INVALID_OPTIONS) {
             /**
-             * Fall fast without retry
+             * Fail fast without retry
              * - Invalid DNS name will not change after retry.
-             * - TLS negotiation is expensive and retry will not help in most case.
              */
             AWS_LOGF_ERROR(
                 AWS_LS_S3_META_REQUEST,


### PR DESCRIPTION
Failed TLS negotiation happens more often than expected, and it is a recoverable error. Hence retry it.

Resolves #477.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
