### PR TITLE
Remove Const for copy_source_uri

### DIFF
--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -877,7 +877,7 @@ struct aws_s3_meta_request_options {
      * If performing a copy operation, provide the source URI here to bypass limitations 1 and 2 of the copy operation.
      * This will be ignored for other operations.
      */
-    const struct aws_byte_cursor copy_source_uri;
+    struct aws_byte_cursor copy_source_uri;
 };
 
 /* Result details of a meta request.


### PR DESCRIPTION
*Description of changes:*
The CPP SDK directly uses the Aws-c-s3, and customers can update Aws-c-s3 independently of the SDK. Making it const creates issues in CPP since the compiler cannot construct it automatically if it's const and removes the default/copy constructors, which is breaking customers. Remove the const since it's not necessary. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
