### PR TITLE
Adapt to aws_base64_compute_encoded_len() no longer adding 1 extra for null terminator

### DIFF
--- a/source/s3_chunk_stream.c
+++ b/source/s3_chunk_stream.c
@@ -259,10 +259,9 @@ struct aws_input_stream *aws_chunk_stream_new(
     if (aws_input_stream_get_length(impl->current_stream, &prechunk_stream_len)) {
         goto error;
     }
-    /* we subtract one since aws_base64_compute_encoded_len accounts for the null terminator which won't show up in our
-     * stream */
+
     impl->length = prechunk_stream_len + stream_length + final_chunk_len + impl->checksum_header_name.len + colon_len +
-                   encoded_checksum_len + post_trailer_len - 1;
+                   encoded_checksum_len + post_trailer_len;
 
     AWS_ASSERT(impl->current_stream);
     aws_ref_count_init(&impl->base.ref_count, impl, (aws_simple_completion_callback *)s_aws_input_chunk_stream_destroy);

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -1246,7 +1246,7 @@ static void s_get_part_response_headers_checksum_helper(
         if (s_header_value_from_list(headers, headers_count, algorithm_header_name, &header_sum)) {
             size_t encoded_len = 0;
             aws_base64_compute_encoded_len(aws_get_digest_size_from_checksum_algorithm(algorithm), &encoded_len);
-            if (header_sum.len == encoded_len - 1) {
+            if (header_sum.len == encoded_len) {
                 aws_byte_buf_init_copy_from_cursor(
                     &connection->request->request_level_response_header_checksum, meta_request->allocator, header_sum);
                 connection->request->request_level_running_response_sum =

--- a/source/s3_util.c
+++ b/source/s3_util.c
@@ -746,8 +746,7 @@ int aws_s3_check_headers_for_checksum(
             /* Found the checksum header, keep the header value and initialize the running checksum */
             size_t encoded_len = 0;
             aws_base64_compute_encoded_len(aws_get_digest_size_from_checksum_algorithm(algorithm), &encoded_len);
-            if (checksum_value.len == encoded_len - 1) {
-                /* encoded_len includes the nullptr length. -1 is the expected length. */
+            if (checksum_value.len == encoded_len) {
                 aws_byte_buf_init_copy_from_cursor(out_checksum_buffer, meta_request->allocator, checksum_value);
                 *out_checksum = aws_checksum_new(meta_request->allocator, algorithm);
                 if (!*out_checksum) {


### PR DESCRIPTION
See: https://github.com/awslabs/aws-c-common/pull/1188

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
