### PR TITLE
Bump Default Memory Limit for Higher Target Throughput

### DIFF
--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -318,9 +318,13 @@ struct aws_s3_client *aws_s3_client_new(
             mem_limit = GB_TO_BYTES(1);
         }
 #else
-        if (client_config->throughput_target_gbps > 75.0) {
+        if (client_config->throughput_target_gbps >= 200.0) {
+            mem_limit = GB_TO_BYTES(24);
+        } else if (client_config->throughput_target_gbps >= 100.0) {
+            mem_limit = GB_TO_BYTES(16);
+        } else if (client_config->throughput_target_gbps >= 75.0) {
             mem_limit = GB_TO_BYTES(8);
-        } else if (client_config->throughput_target_gbps > 25.0) {
+        } else if (client_config->throughput_target_gbps >= 25.0) {
             mem_limit = GB_TO_BYTES(4);
         } else {
             mem_limit = GB_TO_BYTES(2);


### PR DESCRIPTION
*Description of changes:*
- Bump the memory limit for target_throughput >= 100. While doing testing on trn1.32xlarge with 4 NICs and 400 target_throughput, I noticed that bumping up the memory limit results in a ~11% higher throughput. It also makes 100 Gbps target_throughput more stable. So bump the memory limit while we gather more data on what's going on under the hood.

<img width="1189" alt="image" src="https://github.com/user-attachments/assets/5d9b729e-a880-4d30-a3f7-73d3d8cd58f9" />

<img width="1086" alt="Screenshot 2025-03-12 at 11 38 16 AM" src="https://github.com/user-attachments/assets/917f1f9c-2bf3-4c3f-b17b-be2069113a4c" />

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
