### PR TITLE
add request ID to debug level log

### DIFF
--- a/include/aws/s3/private/s3_request.h
+++ b/include/aws/s3/private/s3_request.h
@@ -210,6 +210,11 @@ struct aws_s3_request {
         /* Returned response status of this request. */
         int response_status;
 
+        /* Returned request ID of this request. */
+        struct aws_string *request_id;
+        /* Returned amz ID 2 of this request. */
+        struct aws_string *amz_id_2;
+
         /* The metrics for the request telemetry */
         struct aws_s3_request_metrics *metrics;
 

--- a/include/aws/s3/private/s3_util.h
+++ b/include/aws/s3/private/s3_util.h
@@ -127,6 +127,7 @@ extern const struct aws_byte_cursor g_range_header_name;
 extern const struct aws_byte_cursor g_if_match_header_name;
 
 extern const struct aws_byte_cursor g_request_id_header_name;
+extern const struct aws_byte_cursor g_amz_id_2_header_name;
 
 AWS_S3_API
 extern const struct aws_byte_cursor g_content_range_header_name;

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -1629,7 +1629,8 @@ void aws_s3_meta_request_send_request_finish_default(
 
     AWS_LOGF_DEBUG(
         AWS_LS_S3_META_REQUEST,
-        "id=%p: Request %p finished with error code %d (%s) and response status %d, x-amz-request-id: %s, x-amz-id-2: %s",
+        "id=%p: Request %p finished with error code %d (%s) and response status %d, x-amz-request-id: %s, x-amz-id-2: "
+        "%s",
         (void *)meta_request,
         (void *)request,
         error_code,

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -1276,6 +1276,7 @@ static int s_s3_meta_request_incoming_headers(
 
     struct aws_s3_meta_request *meta_request = request->meta_request;
     AWS_PRECONDITION(meta_request);
+    bool collect_metrics = request->send_data.metrics != NULL;
 
     if (aws_http_stream_get_incoming_response_status(stream, &request->send_data.response_status)) {
         AWS_LOGF_ERROR(
@@ -1284,22 +1285,12 @@ static int s_s3_meta_request_incoming_headers(
             (void *)meta_request,
             (void *)request);
     }
-    if (request->send_data.metrics) {
+
+    if (collect_metrics) {
         /* Record the headers to the metrics */
         struct aws_s3_request_metrics *s3_metrics = request->send_data.metrics;
         if (s3_metrics->req_resp_info_metrics.response_headers == NULL) {
             s3_metrics->req_resp_info_metrics.response_headers = aws_http_headers_new(meta_request->allocator);
-        }
-
-        for (size_t i = 0; i < headers_count; ++i) {
-            const struct aws_byte_cursor *name = &headers[i].name;
-            const struct aws_byte_cursor *value = &headers[i].value;
-            if (aws_byte_cursor_eq(name, &g_request_id_header_name)) {
-                s3_metrics->req_resp_info_metrics.request_id =
-                    aws_string_new_from_cursor(connection->request->allocator, value);
-            }
-
-            aws_http_headers_add(s3_metrics->req_resp_info_metrics.response_headers, *name, *value);
         }
         s3_metrics->req_resp_info_metrics.response_status = request->send_data.response_status;
     }
@@ -1320,11 +1311,25 @@ static int s_s3_meta_request_incoming_headers(
         if (request->send_data.response_headers == NULL) {
             request->send_data.response_headers = aws_http_headers_new(meta_request->allocator);
         }
+    }
 
-        for (size_t i = 0; i < headers_count; ++i) {
-            const struct aws_byte_cursor *name = &headers[i].name;
-            const struct aws_byte_cursor *value = &headers[i].value;
-
+    for (size_t i = 0; i < headers_count; ++i) {
+        const struct aws_byte_cursor *name = &headers[i].name;
+        const struct aws_byte_cursor *value = &headers[i].value;
+        if (request->send_data.request_id == NULL && aws_byte_cursor_eq(name, &g_request_id_header_name)) {
+            request->send_data.request_id = aws_string_new_from_cursor(connection->request->allocator, value);
+            if (collect_metrics) {
+                request->send_data.metrics->req_resp_info_metrics.request_id =
+                    aws_string_new_from_cursor(connection->request->allocator, value);
+            }
+        }
+        if (request->send_data.amz_id_2 == NULL && aws_byte_cursor_eq(name, &g_amz_id_2_header_name)) {
+            request->send_data.amz_id_2 = aws_string_new_from_cursor(connection->request->allocator, value);
+        }
+        if (collect_metrics) {
+            aws_http_headers_add(request->send_data.metrics->req_resp_info_metrics.response_headers, *name, *value);
+        }
+        if (should_record_headers) {
             aws_http_headers_add(request->send_data.response_headers, *name, *value);
         }
     }
@@ -1624,12 +1629,14 @@ void aws_s3_meta_request_send_request_finish_default(
 
     AWS_LOGF_DEBUG(
         AWS_LS_S3_META_REQUEST,
-        "id=%p: Request %p finished with error code %d (%s) and response status %d",
+        "id=%p: Request %p finished with error code %d (%s) and response status %d, request id: %s, amz_id_2: %s",
         (void *)meta_request,
         (void *)request,
         error_code,
         aws_error_debug_str(error_code),
-        response_status);
+        response_status,
+        request->send_data.request_id ? aws_string_c_str(request->send_data.request_id) : "N/A",
+        request->send_data.amz_id_2 ? aws_string_c_str(request->send_data.amz_id_2) : "N/A");
 
     enum aws_s3_connection_finish_code finish_code = AWS_S3_CONNECTION_FINISH_CODE_FAILED;
 

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -1629,7 +1629,7 @@ void aws_s3_meta_request_send_request_finish_default(
 
     AWS_LOGF_DEBUG(
         AWS_LS_S3_META_REQUEST,
-        "id=%p: Request %p finished with error code %d (%s) and response status %d, request id: %s, amz_id_2: %s",
+        "id=%p: Request %p finished with error code %d (%s) and response status %d, x-amz-request-id: %s, x-amz-id-2: %s",
         (void *)meta_request,
         (void *)request,
         error_code,

--- a/source/s3_request.c
+++ b/source/s3_request.c
@@ -100,6 +100,8 @@ void aws_s3_request_clean_up_send_data(struct aws_s3_request *request) {
     request->send_data.signable = NULL;
     aws_http_headers_release(request->send_data.response_headers);
     request->send_data.response_headers = NULL;
+    aws_string_destroy(request->send_data.request_id);
+    aws_string_destroy(request->send_data.amz_id_2);
 
     aws_byte_buf_clean_up(&request->send_data.response_body);
 

--- a/source/s3_util.c
+++ b/source/s3_util.c
@@ -29,6 +29,7 @@ const struct aws_byte_cursor g_host_header_name = AWS_BYTE_CUR_INIT_FROM_STRING_
 const struct aws_byte_cursor g_range_header_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("Range");
 const struct aws_byte_cursor g_if_match_header_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("If-Match");
 const struct aws_byte_cursor g_request_id_header_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("x-amz-request-id");
+const struct aws_byte_cursor g_amz_id_2_header_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("x-amz-id-2");
 const struct aws_byte_cursor g_etag_header_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("ETag");
 const struct aws_byte_cursor g_content_range_header_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("Content-Range");
 const struct aws_byte_cursor g_content_type_header_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("Content-Type");


### PR DESCRIPTION
*Issue #, if available:*

- AWS CLI don't expose the option to set the trace level log from us. https://github.com/aws/aws-cli/blob/v2/awscli/logger.py#L80
- Our debug level log doesn't have request ID which is very help to debug the issue.
- Add the request id to our debug level log

*Description of changes:*
- Well, we need to string compare for every response headers now, I can run some benchmark, but likely it's not the bottle neck of anything


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
