### PR TITLE
prepare in parallel

### DIFF
--- a/source/s3_auto_ranged_put.c
+++ b/source/s3_auto_ranged_put.c
@@ -12,6 +12,7 @@
 #include <aws/common/encoding.h>
 #include <aws/common/string.h>
 #include <aws/io/stream.h>
+#include <aws/io/event_loop.h>
 
 /* TODO: better logging of steps */
 
@@ -992,9 +993,11 @@ struct aws_future_http_message *s_s3_prepare_upload_part(struct aws_s3_request *
             request->request_body.capacity = request_body_size;
         }
 
+        struct aws_event_loop *loop = aws_event_loop_group_get_next_loop(request->meta_request->client->body_streaming_elg);
+
         part_prep->asyncstep_read_part = aws_s3_meta_request_read_body(meta_request, offset, &request->request_body);
-        aws_future_bool_register_callback(
-            part_prep->asyncstep_read_part, s_s3_prepare_upload_part_on_read_done, part_prep);
+        aws_future_bool_register_event_loop_callback(
+            part_prep->asyncstep_read_part, loop, s_s3_prepare_upload_part_on_read_done, part_prep);
     } else {
         /* Not the first time preparing request (e.g. retry).
          * We can skip over the async steps that read the body stream */


### PR DESCRIPTION
*Issue #, if available:*
- The only step for preparation needs to be serial is reading from the original body for now.
- So, invoke the callback after reading from separate threads to make the following steps to happen in parallel
- For s3 express, which we can hit 100Gb/s upload from a 30 GiB streaming data, the rest of the steps happens in the critical path make the performance drops to around 60 - 70 gbps
- With this change, we can hit 100gbps upload again with parts level checksum enabled for that workload.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
