### PR TITLE
Remove Windows 2019 and add Windows 2025 with MSVC-17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,24 +69,24 @@ jobs:
           - name: gcc-8
           - name: gcc-11
           - name: gcc-13
-          # See Issue: https://github.com/llvm/llvm-project/issues/59007. Although this issue 
-          # has been fixed in LLVM, the fix will probably not propagate to older versions of Ubuntu and GCC 13.1. 
+          # See Issue: https://github.com/llvm/llvm-project/issues/59007. Although this issue
+          # has been fixed in LLVM, the fix will probably not propagate to older versions of Ubuntu and GCC 13.1.
           #
-          # Starting with GLIBC version 2.34, the `dn_expand` function, previously found in `libresolv.so`, was moved to `libc.so`. This 
+          # Starting with GLIBC version 2.34, the `dn_expand` function, previously found in `libresolv.so`, was moved to `libc.so`. This
           # function is used internally by the `getaddrinfo()` system call.
           #
-          # In our setup (As of December 2024), we are using an Ubuntu 18 Docker image on a newer Ubuntu host. 
+          # In our setup (As of December 2024), we are using an Ubuntu 18 Docker image on a newer Ubuntu host.
           # However, due to compatibility issues between newer libasan.so in GCC 13.1
-          # and the older Ubuntu image, the linker does not link with `libresolv.so`. 
+          # and the older Ubuntu image, the linker does not link with `libresolv.so`.
           # This results in crashes in `getaddrinfo()` since Ubuntu-18 GLIBC is 2.31.
           #
-          # This problem does not occur on Ubuntu 22 and newer because GLIBC versions 2.34 
-          # and above include `dn_expand` in `libc.so`, eliminating the dependency on 
+          # This problem does not occur on Ubuntu 22 and newer because GLIBC versions 2.34
+          # and above include `dn_expand` in `libc.so`, eliminating the dependency on
           # `libresolv.so`.
           #
-          # We can bypass this problem by linking with "resolv" manually until we bump 
+          # We can bypass this problem by linking with "resolv" manually until we bump
           # our base Linux image to Ubuntu 22.
-            extra-build-flag: --cmake-extra=-DCMAKE_EXE_LINKER_FLAGS="-lresolv" 
+            extra-build-flag: --cmake-extra=-DCMAKE_EXE_LINKER_FLAGS="-lresolv"
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -141,7 +141,7 @@ jobs:
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBYO_CRYPTO=ON --cmake-extra=-DASSERT_LOCK_HELD=ON
 
   windows:
-    runs-on: windows-2022 # latest
+    runs-on: windows-2025 # latest
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -152,8 +152,8 @@ jobs:
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DASSERT_LOCK_HELD=ON
 
-  windows-vc14:
-    runs-on: windows-2019 # windows-2019 is last env with Visual Studio 2015 (v14.0)
+  windows-vc17:
+    runs-on: windows-2025 # latest
     strategy:
       fail-fast: false
       matrix:
@@ -166,10 +166,10 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --target windows-${{ matrix.arch }} --cmake-extra=-DASSERT_LOCK_HELD=ON --compiler msvc-14
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --target windows-${{ matrix.arch }} --cmake-extra=-DASSERT_LOCK_HELD=ON --compiler msvc-17
 
   windows-shared-libs:
-    runs-on: windows-2022 # latest
+    runs-on: windows-2025 # latest
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -181,7 +181,7 @@ jobs:
         python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBUILD_SHARED_LIBS=ON --cmake-extra=-DASSERT_LOCK_HELD=ON
 
   windows-app-verifier:
-    runs-on: windows-2022 # latest
+    runs-on: windows-2025 # latest
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:


### PR DESCRIPTION
- Windows 2019 will be fully unsupported by 2025-06-30, https://github.com/actions/runner-images/issues/12045. Remove it with msvc-15 and below.
- Add new windows 2025 and msvc-17