### PR TITLE
don't regenerate the checksum

### DIFF
--- a/include/aws/s3/private/s3_checksums.h
+++ b/include/aws/s3/private/s3_checksums.h
@@ -93,7 +93,9 @@ struct aws_input_stream *aws_checksum_stream_new(
  * @param existing_stream   The data to be chunkified prepended by information on the stream length followed by a final
  *                          chunk and a trailing chunk containing a checksum of the existing stream. Destroying the
  *                          chunk stream will destroy the existing stream.
- * @param checksum_buffer   Required.
+ * @param checksum_buffer   Optional.
+ *                          - If the checksum_buffer is NULL, the checksum will still be calculated to append as
+ *                          trailer.
  *                          - Empty buffer, the buffer will be initialized to the appropriate size and
  *                          filled with the checksum result when calculated. Callers responsibility to cleanup.
  *                          - Otherwise, the buffer will be used directly.

--- a/include/aws/s3/private/s3_checksums.h
+++ b/include/aws/s3/private/s3_checksums.h
@@ -93,15 +93,18 @@ struct aws_input_stream *aws_checksum_stream_new(
  * @param existing_stream   The data to be chunkified prepended by information on the stream length followed by a final
  *                          chunk and a trailing chunk containing a checksum of the existing stream. Destroying the
  *                          chunk stream will destroy the existing stream.
- * @param checksum_output   Optional argument, if provided the buffer will be initialized to the appropriate size and
+ * @param checksum_buffer   Required.
+ *                          - Empty buffer, the buffer will be initialized to the appropriate size and
  *                          filled with the checksum result when calculated. Callers responsibility to cleanup.
+ *                          - Otherwise, the buffer will be used directly.
+ *                          Caller takes the ownership of the buffer, error or not.
  */
 AWS_S3_API
 struct aws_input_stream *aws_chunk_stream_new(
     struct aws_allocator *allocator,
     struct aws_input_stream *existing_stream,
     enum aws_s3_checksum_algorithm algorithm,
-    struct aws_byte_buf *checksum_output);
+    struct aws_byte_buf *checksum_buffer);
 
 /**
  * Get the size of the checksum output corresponding to the aws_s3_checksum_algorithm enum value.

--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -174,6 +174,8 @@ struct aws_s3_client_vtable {
     struct aws_http_stream *(*http_connection_make_request)(
         struct aws_http_connection *client_connection,
         const struct aws_http_make_request_options *options);
+
+    void (*after_prepare_upload_part_finish)(struct aws_s3_request *request);
 };
 
 struct aws_s3_upload_part_timeout_stats {

--- a/include/aws/s3/private/s3_request_messages.h
+++ b/include/aws/s3/private/s3_request_messages.h
@@ -53,7 +53,7 @@ struct aws_input_stream *aws_s3_message_util_assign_body(
     struct aws_byte_buf *byte_buf,
     struct aws_http_message *out_message,
     const struct checksum_config_storage *checksum_config,
-    struct aws_byte_buf *out_checksum);
+    struct aws_byte_buf *checksum_buf);
 
 /* Create an HTTP request for an S3 Ranged Get Object Request, using the given request as a basis */
 AWS_S3_API
@@ -90,7 +90,7 @@ struct aws_http_message *aws_s3_upload_part_message_new(
     const struct aws_string *upload_id,
     bool should_compute_content_md5,
     const struct checksum_config_storage *checksum_config,
-    struct aws_byte_buf *encoded_checksum_output);
+    struct aws_byte_buf *encoded_checksum);
 
 /* Create an HTTP request for an S3 UploadPartCopy request, using the original request as a basis.
  * If multipart is not needed, part number and upload_id can be 0 and NULL,

--- a/tests/s3_checksum_stream_test.c
+++ b/tests/s3_checksum_stream_test.c
@@ -143,6 +143,7 @@ static int compare_chunk_stream(
     struct aws_byte_buf read_buf;
     aws_byte_buf_init(&read_buf, allocator, buffer_size);
     for (size_t i = 0; i < AWS_ARRAY_SIZE(s_checksum_algo_priority_list); i++) {
+        AWS_ZERO_STRUCT(streamed_encoded_checksum);
         enum aws_s3_checksum_algorithm algorithm = s_checksum_algo_priority_list[i];
         aws_base64_compute_encoded_len(aws_get_digest_size_from_checksum_algorithm(algorithm), &encoded_len);
         size_t total_len =

--- a/tests/s3_mock_server_tests.c
+++ b/tests/s3_mock_server_tests.c
@@ -434,12 +434,23 @@ TEST_CASE(multipart_upload_with_network_interface_names_mock_server) {
 #endif
 }
 
+/* Total hack to flip the bytes. */
+static void s_after_prepare_upload_part_finish(struct aws_s3_request *request) {
+    if (request->num_times_prepared > 1) {
+        /* mock that the body buffer was messed up in memory */
+        request->request_body.buffer[1]++;
+    }
+}
+
+/**
+ * This test is built for
+ * 1. We had a memory leak when the retry was triggered and the checksum was calculated.
+ *      The retry will initialize the checksum buffer again, but the previous one was not freed.
+ * 2. We had a bug where the retry will mangle the data with the error response from server.
+ * 3. Don't recalculate the checksum when retrying.
+ */
 TEST_CASE(multipart_upload_checksum_with_retry_mock_server) {
     (void)ctx;
-    /**
-     * We had a memory leak when the retry was triggered and the checksum was calculated.
-     * The retry will initialize the checksum buffer again, but the previous one was not freed.
-     */
     struct aws_s3_tester tester;
     ASSERT_SUCCESS(aws_s3_tester_init(allocator, &tester));
     struct aws_s3_tester_client_options client_options = {
@@ -449,37 +460,73 @@ TEST_CASE(multipart_upload_checksum_with_retry_mock_server) {
 
     struct aws_s3_client *client = NULL;
     ASSERT_SUCCESS(aws_s3_tester_client_new(&tester, &client_options, &client));
+    struct aws_s3_client_vtable *patched_client_vtable = aws_s3_tester_patch_client_vtable(&tester, client, NULL);
+    patched_client_vtable->after_prepare_upload_part_finish = s_after_prepare_upload_part_finish;
 
     struct aws_byte_cursor object_path = aws_byte_cursor_from_c_str("/throttle");
+    {
+        /* 1. Trailer checksum */
+        struct aws_s3_tester_meta_request_options put_options = {
+            .allocator = allocator,
+            .meta_request_type = AWS_S3_META_REQUEST_TYPE_PUT_OBJECT,
+            .client = client,
+            .checksum_algorithm = AWS_SCA_CRC32,
+            .validate_get_response_checksum = false,
+            .put_options =
+                {
+                    .object_size_mb = 10,
+                    .object_path_override = object_path,
+                },
+            .mock_server = true,
+        };
 
-    struct aws_s3_tester_meta_request_options put_options = {
-        .allocator = allocator,
-        .meta_request_type = AWS_S3_META_REQUEST_TYPE_PUT_OBJECT,
-        .client = client,
-        .checksum_algorithm = AWS_SCA_CRC32,
-        .validate_get_response_checksum = false,
-        .put_options =
-            {
-                .object_size_mb = 10,
-                .object_path_override = object_path,
-            },
-        .mock_server = true,
-    };
+        struct aws_s3_meta_request_test_results meta_request_test_results;
+        aws_s3_meta_request_test_results_init(&meta_request_test_results, allocator);
 
-    struct aws_s3_meta_request_test_results meta_request_test_results;
-    aws_s3_meta_request_test_results_init(&meta_request_test_results, allocator);
+        ASSERT_SUCCESS(aws_s3_tester_send_meta_request_with_options(&tester, &put_options, &meta_request_test_results));
 
-    ASSERT_SUCCESS(aws_s3_tester_send_meta_request_with_options(&tester, &put_options, &meta_request_test_results));
+        ASSERT_INT_EQUALS(meta_request_test_results.upload_review.part_count, 2);
+        /* Note: the data we currently generate is always the same,
+         * so make sure that retry does not mangle the data by checking the checksum value */
+        ASSERT_STR_EQUALS(
+            "7/xUXw==", aws_string_c_str(meta_request_test_results.upload_review.part_checksums_array[0]));
+        ASSERT_STR_EQUALS(
+            "PCOjcw==", aws_string_c_str(meta_request_test_results.upload_review.part_checksums_array[1]));
+        aws_s3_meta_request_test_results_clean_up(&meta_request_test_results);
+    }
+    {
+        /* 2. header checksum */
+        struct aws_s3_tester_meta_request_options put_options = {
+            .allocator = allocator,
+            .meta_request_type = AWS_S3_META_REQUEST_TYPE_PUT_OBJECT,
+            .client = client,
+            .checksum_algorithm = AWS_SCA_CRC32,
+            .checksum_via_header = true,
+            .validate_get_response_checksum = false,
+            .put_options =
+                {
+                    .object_size_mb = 10,
+                    .object_path_override = object_path,
+                },
+            .mock_server = true,
+        };
 
-    ASSERT_INT_EQUALS(meta_request_test_results.upload_review.part_count, 2);
-    /* Note: the data we currently generate is always the same,
-     * so make sure that retry does not mangle the data by checking the checksum value */
-    ASSERT_STR_EQUALS("7/xUXw==", aws_string_c_str(meta_request_test_results.upload_review.part_checksums_array[0]));
-    ASSERT_STR_EQUALS("PCOjcw==", aws_string_c_str(meta_request_test_results.upload_review.part_checksums_array[1]));
+        struct aws_s3_meta_request_test_results meta_request_test_results;
+        aws_s3_meta_request_test_results_init(&meta_request_test_results, allocator);
 
+        ASSERT_SUCCESS(aws_s3_tester_send_meta_request_with_options(&tester, &put_options, &meta_request_test_results));
+
+        ASSERT_INT_EQUALS(meta_request_test_results.upload_review.part_count, 2);
+        /* Note: the data we currently generate is always the same,
+         * so make sure that retry does not mangle the data by checking the checksum value */
+        ASSERT_STR_EQUALS(
+            "7/xUXw==", aws_string_c_str(meta_request_test_results.upload_review.part_checksums_array[0]));
+        ASSERT_STR_EQUALS(
+            "PCOjcw==", aws_string_c_str(meta_request_test_results.upload_review.part_checksums_array[1]));
+        aws_s3_meta_request_test_results_clean_up(&meta_request_test_results);
+    }
     aws_s3_client_release(client);
     aws_s3_tester_clean_up(&tester);
-    aws_s3_meta_request_test_results_clean_up(&meta_request_test_results);
 
     return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION
*Issue #, if available:*
- We previously clean up the checksum after prepare.
- It results in the checksum to be recalculated during retry
- It's violating the durability guarantee 
- However, since we already buffer the input in memory during retry, it won't read the customer input again, which mitigated the impact.

*Description of changes:*
- Revamp the code a bit to allow the passed in checksum to the input stream wrappers. So that it won't recalculate the checksum

### TODO:
- The whole checksum logic is already complicated this makes it more weird, need to revamp it...
- I'd prefer to push the revamp of the checksum logic later when we implement the full object checksum. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
