### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   clang-format:
 


### PR DESCRIPTION
Potential fix for [https://github.com/awslabs/aws-c-s3/security/code-scanning/2](https://github.com/awslabs/aws-c-s3/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only checks out sources and runs a linting script, it does not require write permissions. The minimal permissions required are `contents: read`. This block can be added at the root level of the workflow to apply to all jobs, or specifically to the `clang-format` job.

The best approach is to add the `permissions` block at the root level of the workflow for simplicity and clarity, as there is only one job in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
