### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -1,4 +1,7 @@
 name: Closed Issue Message
+permissions:
+    contents: read
+    issues: write
 on:
     issues:
        types: [closed]


### PR DESCRIPTION
Potential fix for [https://github.com/awslabs/aws-c-s3/security/code-scanning/1](https://github.com/awslabs/aws-c-s3/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the functionality of the `aws-actions/closed-issue-message` action, the workflow likely only needs `contents: read` and `issues: write` permissions. These permissions allow the workflow to read repository contents and post comments on issues, which aligns with its intended purpose.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `auto_comment` job. In this case, adding it at the root level is sufficient and ensures clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
