### PR TITLE
Checksum stream with context

### DIFF
--- a/include/aws/s3/private/s3_checksums.h
+++ b/include/aws/s3/private/s3_checksums.h
@@ -104,15 +104,6 @@ AWS_S3_API
 int aws_checksum_stream_finalize_checksum(struct aws_input_stream *checksum_stream, struct aws_byte_buf *checksum_buf);
 
 /**
- * Finalize the checksum has read so far to the checksum context.
- * Not thread safe.
- */
-AWS_S3_API
-int aws_checksum_stream_finalize_checksum_context(
-    struct aws_input_stream *checksum_stream,
-    struct aws_s3_upload_request_checksum_context *checksum_context);
-
-/**
  * TODO: properly support chunked encoding.
  * Creates a chunked encoding stream that wraps an existing stream and adds checksum trailers.
  *

--- a/include/aws/s3/private/s3_checksums.h
+++ b/include/aws/s3/private/s3_checksums.h
@@ -62,6 +62,24 @@ struct aws_s3_meta_request_checksum_config_storage {
 };
 
 /**
+ * a stream that takes in a stream.
+ * The context will be only finalized when the checksum stream has read to the end of stream.
+ * Note: seek this stream will immediately fail, as it would prevent an accurate calculation of the
+ * checksum.
+ *
+ * @param allocator
+ * @param existing_stream The real content to read from. Destroying the checksum stream destroys the existing stream.
+ *                        outputs the checksum of existing stream to checksum_output upon destruction. Will be kept
+ *                        alive by the checksum stream
+ * @param algorithm       Checksum algorithm to use.
+ */
+AWS_S3_API
+struct aws_input_stream *aws_checksum_stream_new_with_context(
+    struct aws_allocator *allocator,
+    struct aws_input_stream *existing_stream,
+    struct aws_s3_upload_request_checksum_context *context);
+
+/**
  * a stream that takes in a stream
  * Note: seek this stream will immediately fail, as it would prevent an accurate calculation of the
  * checksum.

--- a/source/s3_checksum_context.c
+++ b/source/s3_checksum_context.c
@@ -170,6 +170,11 @@ int aws_s3_upload_request_checksum_context_finalize_checksum(
             return AWS_OP_ERR;
         }
         context->synced_data.checksum_calculated = true;
+    } else {
+        AWS_LOGF_ERROR(
+            AWS_LS_S3_GENERAL, "Checksum already finalized. This should not happen. Please file a bug report.");
+        s_unlock_synced_data(context);
+        return aws_raise_error(AWS_ERROR_INVALID_STATE);
     }
     s_unlock_synced_data(context);
     return AWS_OP_SUCCESS;

--- a/source/s3_checksum_context.c
+++ b/source/s3_checksum_context.c
@@ -170,11 +170,6 @@ int aws_s3_upload_request_checksum_context_finalize_checksum(
             return AWS_OP_ERR;
         }
         context->synced_data.checksum_calculated = true;
-    } else {
-        AWS_LOGF_ERROR(
-            AWS_LS_S3_GENERAL, "Checksum already finalized. This should not happen. Please file a bug report.");
-        s_unlock_synced_data(context);
-        return aws_raise_error(AWS_ERROR_INVALID_STATE);
     }
     s_unlock_synced_data(context);
     return AWS_OP_SUCCESS;

--- a/source/s3_checksum_stream.c
+++ b/source/s3_checksum_stream.c
@@ -48,6 +48,35 @@ static int s_aws_input_checksum_stream_read(struct aws_input_stream *stream, str
     if (aws_checksum_update(impl->checksum, &to_sum)) {
         return AWS_OP_ERR;
     }
+    if (impl->context) {
+        /* If we're at the end of the stream, compute and store the final checksum */
+        struct aws_stream_status status;
+        if (aws_input_stream_get_status(impl->old_stream, &status)) {
+            return AWS_OP_ERR;
+        }
+        if (status.is_end_of_stream) {
+            if (aws_checksum_finalize(impl->checksum, &impl->checksum_result) != AWS_OP_SUCCESS) {
+                AWS_LOGF_ERROR(
+                    AWS_LS_S3_CLIENT,
+                    "Failed to calculate checksum with error code %d (%s).",
+                    aws_last_error(),
+                    aws_error_str(aws_last_error()));
+                aws_byte_buf_reset(&impl->checksum_result, true);
+                return aws_raise_error(AWS_ERROR_S3_CHECKSUM_CALCULATION_FAILED);
+            }
+            struct aws_byte_cursor checksum_result_cursor = aws_byte_cursor_from_buf(&impl->checksum_result);
+            if (aws_s3_upload_request_checksum_context_finalize_checksum(impl->context, checksum_result_cursor) !=
+                AWS_OP_SUCCESS) {
+                AWS_LOGF_ERROR(
+                    AWS_LS_S3_CLIENT,
+                    "Failed to finalize checksum context with error code %d (%s).",
+                    aws_last_error(),
+                    aws_error_str(aws_last_error()));
+                aws_byte_buf_reset(&impl->checksum_result, true);
+                return aws_raise_error(AWS_ERROR_S3_CHECKSUM_CALCULATION_FAILED);
+            }
+        }
+    }
     return AWS_OP_SUCCESS;
 }
 
@@ -82,7 +111,7 @@ static struct aws_input_stream_vtable s_aws_input_checksum_stream_vtable = {
     .get_length = s_aws_input_checksum_stream_get_length,
 };
 
-struct aws_input_stream *aws_checksum_stream_new(
+static struct aws_checksum_stream *s_aws_checksum_input_checksum_stream_new(
     struct aws_allocator *allocator,
     struct aws_input_stream *existing_stream,
     enum aws_s3_checksum_algorithm algorithm) {
@@ -100,10 +129,21 @@ struct aws_input_stream *aws_checksum_stream_new(
     impl->old_stream = aws_input_stream_acquire(existing_stream);
     aws_ref_count_init(
         &impl->base.ref_count, impl, (aws_simple_completion_callback *)s_aws_input_checksum_stream_destroy);
-
-    return &impl->base;
+    return impl;
 on_error:
     aws_mem_release(impl->allocator, impl);
+    return NULL;
+}
+
+struct aws_input_stream *aws_checksum_stream_new(
+    struct aws_allocator *allocator,
+    struct aws_input_stream *existing_stream,
+    enum aws_s3_checksum_algorithm algorithm) {
+    AWS_PRECONDITION(existing_stream);
+    struct aws_checksum_stream *impl = s_aws_checksum_input_checksum_stream_new(allocator, existing_stream, algorithm);
+    if (impl) {
+        return &impl->base;
+    }
     return NULL;
 }
 
@@ -113,42 +153,34 @@ struct aws_input_stream *aws_checksum_stream_new_with_context(
     struct aws_s3_upload_request_checksum_context *context) {
     AWS_PRECONDITION(existing_stream);
     AWS_PRECONDITION(context);
-
-    struct aws_checksum_stream *impl = aws_mem_calloc(allocator, 1, sizeof(struct aws_checksum_stream));
-    impl->allocator = allocator;
-    impl->base.vtable = &s_aws_input_checksum_stream_vtable;
-
-    impl->checksum = aws_checksum_new(allocator, context->algorithm);
-    if (impl->checksum == NULL) {
-        goto on_error;
+    struct aws_checksum_stream *impl =
+        s_aws_checksum_input_checksum_stream_new(allocator, existing_stream, context->algorithm);
+    if (impl) {
+        impl->context = context;
+        return &impl->base;
     }
-    aws_byte_buf_init(&impl->checksum_result, allocator, impl->checksum->digest_size);
-    impl->old_stream = aws_input_stream_acquire(existing_stream);
-    aws_ref_count_init(
-        &impl->base.ref_count, impl, (aws_simple_completion_callback *)s_aws_input_checksum_stream_destroy);
-    impl->context = context;
-    return &impl->base;
-on_error:
-    aws_mem_release(impl->allocator, impl);
     return NULL;
 }
 
 int aws_checksum_stream_finalize_checksum(struct aws_input_stream *checksum_stream, struct aws_byte_buf *checksum_buf) {
     AWS_PRECONDITION(checksum_buf);
     AWS_PRECONDITION(checksum_buf->len == 0 && "Checksum output buffer is not empty");
+    int rt_code = AWS_OP_ERR;
 
     struct aws_checksum_stream *impl = AWS_CONTAINER_OF(checksum_stream, struct aws_checksum_stream, base);
+    struct aws_byte_buf checksum_result;
+    aws_byte_buf_init(&checksum_result, impl->allocator, impl->checksum->digest_size);
 
-    if (aws_checksum_finalize(impl->checksum, &impl->checksum_result) != AWS_OP_SUCCESS) {
+    if (aws_checksum_finalize(impl->checksum, &checksum_result) != AWS_OP_SUCCESS) {
         AWS_LOGF_ERROR(
             AWS_LS_S3_CLIENT,
             "Failed to calculate checksum with error code %d (%s).",
             aws_last_error(),
             aws_error_str(aws_last_error()));
-        aws_byte_buf_reset(&impl->checksum_result, true);
-        return aws_raise_error(AWS_ERROR_S3_CHECKSUM_CALCULATION_FAILED);
+        aws_raise_error(AWS_ERROR_S3_CHECKSUM_CALCULATION_FAILED);
+        goto done;
     }
-    struct aws_byte_cursor checksum_result_cursor = aws_byte_cursor_from_buf(&impl->checksum_result);
+    struct aws_byte_cursor checksum_result_cursor = aws_byte_cursor_from_buf(&checksum_result);
     if (aws_base64_encode(&checksum_result_cursor, checksum_buf) != AWS_OP_SUCCESS) {
         AWS_LOGF_ERROR(
             AWS_LS_S3_CLIENT,
@@ -157,37 +189,11 @@ int aws_checksum_stream_finalize_checksum(struct aws_input_stream *checksum_stre
             aws_error_str(aws_last_error()),
             checksum_buf->capacity,
             checksum_buf->len);
-        aws_byte_buf_reset(&impl->checksum_result, true);
-        return aws_raise_error(AWS_ERROR_S3_CHECKSUM_CALCULATION_FAILED);
+        aws_raise_error(AWS_ERROR_S3_CHECKSUM_CALCULATION_FAILED);
+        goto done;
     }
-
-    return AWS_OP_SUCCESS;
-}
-
-int aws_checksum_stream_finalize_checksum_context(
-    struct aws_input_stream *checksum_stream,
-    struct aws_s3_upload_request_checksum_context *checksum_context) {
-    struct aws_checksum_stream *impl = AWS_CONTAINER_OF(checksum_stream, struct aws_checksum_stream, base);
-
-    if (aws_checksum_finalize(impl->checksum, &impl->checksum_result) != AWS_OP_SUCCESS) {
-        AWS_LOGF_ERROR(
-            AWS_LS_S3_CLIENT,
-            "Failed to calculate checksum with error code %d (%s).",
-            aws_last_error(),
-            aws_error_str(aws_last_error()));
-        aws_byte_buf_reset(&impl->checksum_result, true);
-        return aws_raise_error(AWS_ERROR_S3_CHECKSUM_CALCULATION_FAILED);
-    }
-    struct aws_byte_cursor checksum_result_cursor = aws_byte_cursor_from_buf(&impl->checksum_result);
-    if (aws_s3_upload_request_checksum_context_finalize_checksum(checksum_context, checksum_result_cursor) !=
-        AWS_OP_SUCCESS) {
-        AWS_LOGF_ERROR(
-            AWS_LS_S3_CLIENT,
-            "Failed to finalize checksum context with error code %d (%s).",
-            aws_last_error(),
-            aws_error_str(aws_last_error()));
-        aws_byte_buf_reset(&impl->checksum_result, true);
-        return aws_raise_error(AWS_ERROR_S3_CHECKSUM_CALCULATION_FAILED);
-    }
-    return AWS_OP_SUCCESS;
+    rt_code = AWS_OP_SUCCESS;
+done:
+    aws_byte_buf_clean_up(&checksum_result);
+    return rt_code;
 }


### PR DESCRIPTION
*Issue #, if available:*

- Let the checksum stream take a context.
- In which case, when the stream read to the end, it finalizes the checksum to the context.
- Since, the caller may not know when exact the stream finishes reading.
  - when the s3 request takes the checksum stream directly, we want to reuse the checksum if the previous read finish reading during retry.
  - But, in the meantime, S3 request don't know the stream finished reading or not. So, still let the stream to finalize the checksum after reading the end of the stream.

*Description of changes:*



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
