### PR TITLE
Direct I/O integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,12 +71,3 @@ benchmarks/dashboard-stack/package-lock.json
 
 # virtual environment
 .venv/
-
-*.csv
-*.png
-
-stats.txt
-
-*.py
-
-telemetry/

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,12 @@ benchmarks/dashboard-stack/package-lock.json
 
 # virtual environment
 .venv/
+
+*.csv
+*.png
+
+stats.txt
+
+*.py
+
+telemetry/

--- a/include/aws/s3/private/s3_client_impl.h
+++ b/include/aws/s3/private/s3_client_impl.h
@@ -171,7 +171,8 @@ struct aws_s3_client_vtable {
     struct aws_parallel_input_stream *(*parallel_input_stream_new_from_file)(
         struct aws_allocator *allocator,
         struct aws_byte_cursor file_name,
-        struct aws_event_loop_group *reading_elg);
+        struct aws_event_loop_group *reading_elg,
+        bool direct_io_read);
 
     struct aws_http_stream *(*http_connection_make_request)(
         struct aws_http_connection *client_connection,

--- a/include/aws/s3/private/s3_parallel_input_stream.h
+++ b/include/aws/s3/private/s3_parallel_input_stream.h
@@ -123,16 +123,24 @@ int aws_parallel_input_stream_get_length(struct aws_parallel_input_stream *strea
  * Creates a new parallel input stream that reads from a file.
  * This stream uses an event loop group to perform file I/O operations asynchronously.
  *
+ * Notes for direct_io_read:
+ * - checking `aws_file_path_read_from_offset_direct_io` for detail
+ * - For `AWS_ERROR_UNSUPPORTED_OPERATION`, fallback to reading with cache with warnings, instead of fail.
+ * - If alignment required, it's callers' responsibility to align with the page size.
+ *
  * @param allocator The allocator to use for memory allocation
  * @param file_name The name of the file to read from
  * @param reading_elg The event loop group to use for file I/O operations
+ * @param direct_io_read Whether to use direct I/O for reading the file.
+ *
  * @return A new parallel input stream that reads from the specified file
  */
 AWS_S3_API
 struct aws_parallel_input_stream *aws_parallel_input_stream_new_from_file(
     struct aws_allocator *allocator,
     struct aws_byte_cursor file_name,
-    struct aws_event_loop_group *reading_elg);
+    struct aws_event_loop_group *reading_elg,
+    bool direct_io_read);
 
 /**
  * Get the shutdown future from the parallel input stream.

--- a/include/aws/s3/private/s3_part_streaming_input_stream.h
+++ b/include/aws/s3/private/s3_part_streaming_input_stream.h
@@ -24,11 +24,13 @@ AWS_EXTERN_C_BEGIN
  *      will be used from `para_stream` to handle the parallel read, it's subjected to a dead lock!!
  *      Make sure the input stream is read from a different thread/thread pool that executes the `para_stream` reads.
  *
- * @param allocator The allocator to use for memory allocation
- * @param para_stream The parallel input stream to read from
- * @param buffer_ticket The buffer pool ticket to use for buffering
- * @param offset The starting offset in the stream
- * @param request_body_size The total size to read
+ * @param allocator             The allocator to use for memory allocation
+ * @param para_stream           The parallel input stream to read from
+ * @param buffer_ticket         The buffer pool ticket to use for buffering
+ * @param offset                The starting offset in the stream
+ * @param request_body_size     The total size to read
+ * @param page_aligned          Whether the input stream only read from the para_stream on that
+ *                              aligned with the page size, required for direct I/O in linux.
  * @return A new input stream that reads from the parallel input stream
  */
 AWS_S3_API
@@ -37,7 +39,8 @@ struct aws_input_stream *aws_part_streaming_input_stream_new(
     struct aws_parallel_input_stream *para_stream,
     struct aws_s3_buffer_ticket *buffer_ticket,
     uint64_t offset,
-    size_t request_body_size);
+    size_t request_body_size,
+    bool page_aligned);
 
 AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -339,7 +339,7 @@ struct aws_s3_file_io_options {
     /**
      * Enable direct IO to bypass the OS cache. Helpful when the disk I/O outperforms the kernel cache.
      * Notes:
-     * - Only supported on linux.
+     * - Only supported on linux for now.
      * - Only supports upload for now.
      * - Check NOTES for O_DIRECT for additional info https://man7.org/linux/man-pages/man2/openat.2.html
      * In summary, O_DIRECT is a potentially powerful tool that should be used with caution.

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -319,7 +319,7 @@ enum aws_s3_recv_file_options {
 struct aws_s3_file_io_options {
     /**
      * Skip buffering the part in memory before sending the request.
-     * If set, set the `disk_throughput` to be reasonable align with the available disk throughput.
+     * If set, set the `disk_throughput_gbps` to be reasonable align with the available disk throughput.
      * Otherwise, the transfer may fail with connection starvation.
      * Default to false.
      **/
@@ -334,7 +334,7 @@ struct aws_s3_file_io_options {
      * 1. Disk is busy with other applications
      * 2. OS Cache may cap the throughput, use `direct_io` to get around this.
      **/
-    double disk_throughput;
+    double disk_throughput_gbps;
 
     /**
      * Enable direct IO to bypass the OS cache. Helpful when the disk I/O outperforms the kernel cache.

--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -326,16 +326,6 @@ struct aws_s3_file_io_options {
     bool should_stream;
 
     /**
-     * Enable direct IO to bypass the OS cache. Helpful when the disk I/O outperforms the kernel cache.
-     * Notes:
-     * - Only supported on linux.
-     * - Only supports upload for now.
-     * - Check NOTES for O_DIRECT for additional info https://man7.org/linux/man-pages/man2/openat.2.html
-     * In summary, O_DIRECT is a potentially powerful tool that should be used with caution.
-     */
-    bool direct_io;
-
-    /**
      * The estimated disk throughput. Only be applied when `streaming_upload` is true.
      * in gigabits per second (Gbps).
      *
@@ -345,6 +335,16 @@ struct aws_s3_file_io_options {
      * 2. OS Cache may cap the throughput, use `direct_io` to get around this.
      **/
     double disk_throughput;
+
+    /**
+     * Enable direct IO to bypass the OS cache. Helpful when the disk I/O outperforms the kernel cache.
+     * Notes:
+     * - Only supported on linux.
+     * - Only supports upload for now.
+     * - Check NOTES for O_DIRECT for additional info https://man7.org/linux/man-pages/man2/openat.2.html
+     * In summary, O_DIRECT is a potentially powerful tool that should be used with caution.
+     */
+    bool direct_io;
 };
 
 /**

--- a/source/s3_auto_ranged_put.c
+++ b/source/s3_auto_ranged_put.c
@@ -1085,7 +1085,12 @@ struct aws_future_http_message *s_s3_prepare_upload_part(struct aws_s3_request *
         size_t request_body_size = s_compute_request_body_size(meta_request, request->part_number, &offset);
         AWS_ASSERT(meta_request->request_body_parallel_stream != NULL);
         request->request_body_stream = aws_part_streaming_input_stream_new(
-            allocator, meta_request->request_body_parallel_stream, request->ticket, offset, request_body_size);
+            allocator,
+            meta_request->request_body_parallel_stream,
+            request->ticket,
+            offset,
+            request_body_size,
+            meta_request->fio_opts.direct_io);
         request->content_length = request_body_size;
         int error_code = AWS_ERROR_SUCCESS;
 

--- a/source/s3_client.c
+++ b/source/s3_client.c
@@ -183,14 +183,15 @@ uint32_t aws_s3_client_get_max_active_connections(
         client->max_active_connections_override < max_active_connections) {
         max_active_connections = client->max_active_connections_override;
     }
-    if (meta_request && meta_request->fio_opts.should_stream && meta_request->fio_opts.disk_throughput > 0) {
+    if (meta_request && meta_request->fio_opts.should_stream && meta_request->fio_opts.disk_throughput_gbps > 0) {
         return aws_min_u32(
-            s_get_ideal_connection_number_from_throughput(meta_request->fio_opts.disk_throughput),
+            s_get_ideal_connection_number_from_throughput(meta_request->fio_opts.disk_throughput_gbps),
             max_active_connections);
     }
-    if (client->fio_opts.should_stream && client->fio_opts.disk_throughput > 0) {
+    if (client->fio_opts.should_stream && client->fio_opts.disk_throughput_gbps > 0) {
         return aws_min_u32(
-            s_get_ideal_connection_number_from_throughput(client->fio_opts.disk_throughput), max_active_connections);
+            s_get_ideal_connection_number_from_throughput(client->fio_opts.disk_throughput_gbps),
+            max_active_connections);
     }
 
     return max_active_connections;

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -334,7 +334,7 @@ int aws_s3_meta_request_init_base(
         }
         if (meta_request->fio_opts.direct_io && !meta_request->fio_opts.should_stream) {
             /* TODO: aws_system_info_page_size */
-            size_t page_size = KB_TO_BYTES(4);
+            size_t page_size = aws_system_info_page_size();
             if (part_size % page_size != 0) {
                 AWS_LOGF_ERROR(
                     AWS_LS_S3_META_REQUEST,

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -328,7 +328,7 @@ int aws_s3_meta_request_init_base(
     if (options->send_filepath.len > 0) {
         /* Create parallel read stream from file */
         meta_request->request_body_parallel_stream = client->vtable->parallel_input_stream_new_from_file(
-            allocator, options->send_filepath, client->body_streaming_elg);
+            allocator, options->send_filepath, client->body_streaming_elg, meta_request->fio_opts.direct_io);
         if (meta_request->request_body_parallel_stream == NULL) {
             goto error;
         }

--- a/source/s3_part_streaming_input_stream.c
+++ b/source/s3_part_streaming_input_stream.c
@@ -13,6 +13,7 @@
 #include <aws/common/file.h>
 #include <aws/common/logging.h>
 #include <aws/common/string.h>
+#include <aws/common/system_info.h>
 #include <aws/common/task_scheduler.h>
 #include <aws/common/thread.h>
 
@@ -280,8 +281,7 @@ struct aws_input_stream *aws_part_streaming_input_stream_new(
 
     impl->base.vtable = &s_part_streaming_input_stream_vtable;
 
-    /* TODO: Hard code to 4KB for the page size for now. */
-    impl->page_size = KB_TO_BYTES(4);
+    impl->page_size = aws_system_info_page_size();
     impl->offset = offset;
     int64_t para_stream_total_length = 0;
     if (aws_parallel_input_stream_get_length(para_stream, &para_stream_total_length)) {

--- a/source/s3_part_streaming_input_stream.c
+++ b/source/s3_part_streaming_input_stream.c
@@ -268,7 +268,8 @@ struct aws_input_stream *aws_part_streaming_input_stream_new(
     struct aws_parallel_input_stream *para_stream,
     struct aws_s3_buffer_ticket *buffer_ticket,
     uint64_t offset,
-    size_t request_body_size) {
+    size_t request_body_size,
+    bool page_aligned) {
     AWS_PRECONDITION(para_stream);
     AWS_PRECONDITION(buffer_ticket);
 
@@ -278,20 +279,23 @@ struct aws_input_stream *aws_part_streaming_input_stream_new(
     aws_ref_count_init(
         &impl->base.ref_count, impl, (aws_simple_completion_callback *)s_part_streaming_input_stream_destroy);
     impl->allocator = allocator;
-
     impl->base.vtable = &s_part_streaming_input_stream_vtable;
 
-    impl->page_size = aws_system_info_page_size();
+    if (page_aligned) {
+        impl->page_size = aws_system_info_page_size();
+    } else {
+        /* Disable page alignment by using 1 as the page size */
+        impl->page_size = 1;
+    }
     impl->offset = offset;
     int64_t para_stream_total_length = 0;
     if (aws_parallel_input_stream_get_length(para_stream, &para_stream_total_length)) {
         AWS_LOGF_ERROR(
             AWS_LS_S3_GENERAL,
-            "id=%p: Failed to get length from parallel input stream with error %s",
+            "id=%p: Failed to create part_streaming_input_stream: get length from parallel input stream with error %s",
             (void *)impl,
             aws_error_debug_str(aws_last_error()));
-        aws_mem_release(allocator, impl);
-        return NULL;
+        goto error;
     }
     uint64_t total_available_length = aws_sub_u64_saturating((uint64_t)para_stream_total_length, offset);
     impl->total_length = (size_t)aws_min_u64((uint64_t)request_body_size, total_available_length);
@@ -300,11 +304,36 @@ struct aws_input_stream *aws_part_streaming_input_stream_new(
     impl->ticket = aws_s3_buffer_ticket_acquire(buffer_ticket);
 
     struct aws_byte_buf buffer = aws_s3_buffer_ticket_claim(impl->ticket);
-    AWS_FATAL_ASSERT(buffer.capacity % 2 == 0);
+    if (buffer.capacity % 2 != 0) {
+        AWS_LOGF_ERROR(
+            AWS_LS_S3_GENERAL,
+            "id=%p: Failed to create part_streaming_input_stream: Only supports even length of buffer from the ticket.",
+            (void *)impl);
+        aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
+        goto error;
+    }
+    if (buffer.buffer == NULL || buffer.capacity == 0) {
+        AWS_LOGF_ERROR(
+            AWS_LS_S3_GENERAL,
+            "id=%p: Failed to create part_streaming_input_stream: The buffer from ticket is invalid.",
+            (void *)impl);
+        aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
+        goto error;
+    }
     impl->chunk_load_size = buffer.capacity / 2;
 
-    AWS_FATAL_ASSERT(buffer.buffer);
+    if (impl->chunk_load_size < impl->page_size) {
+        AWS_LOGF_ERROR(
+            AWS_LS_S3_GENERAL,
+            "id=%p: Failed to create part_streaming_input_stream: The buffer from ticket is smaller than the two times "
+            "of page size. Cannot align the page.",
+            (void *)impl);
+        aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
+        goto error;
+    }
+
     /* Split the buffer to the first and second half. */
+    /* There is no need to clean up the buffer acquired from the ticket, only need to release the ticket itself. */
     impl->chunk_buf_1 = aws_byte_buf_from_array(buffer.buffer, impl->chunk_load_size);
     impl->chunk_buf_2 = aws_byte_buf_from_array(buffer.buffer + impl->chunk_load_size, impl->chunk_load_size);
 
@@ -328,8 +357,13 @@ struct aws_input_stream *aws_part_streaming_input_stream_new(
         impl->eos_reached = true;
         AWS_LOGF_TRACE(AWS_LS_S3_GENERAL, "id=%p: Zero-length request, immediately setting EOS", (void *)impl);
     } else {
-        /* Start to load into the loading buffer. */
+        /* Start to load into the loading buffer. Cannot fail the create function after this. */
         s_kick_off_next_load(impl);
     }
     return &impl->base;
+error:
+    aws_parallel_input_stream_release(impl->para_stream);
+    aws_s3_buffer_ticket_release(impl->ticket);
+    aws_mem_release(allocator, impl);
+    return NULL;
 }

--- a/tests/mock_s3_server/mock_s3_server.py
+++ b/tests/mock_s3_server/mock_s3_server.py
@@ -70,7 +70,7 @@ class ResponseConfig:
     def _resolve_file_path(self, wrapper, request_type):
         if self.json_path is None:
             if self.forced_throttle:
-                # force the throttle to happend, instead of just 50%.
+                # force the throttle to happen, for triggering retries.
                 response_file = os.path.join(
                     base_dir, request_type.name, f"throttle.json")
                 self.json_path = response_file

--- a/tests/mock_s3_server/mock_s3_server.py
+++ b/tests/mock_s3_server/mock_s3_server.py
@@ -20,8 +20,6 @@ TIMEOUT = 120  # this must be higher than any response's "delay" setting
 
 VERBOSE = False
 
-# Flags to keep between requests
-SHOULD_THROTTLE = True
 RETRY_REQUEST_COUNT = 0
 
 
@@ -70,7 +68,6 @@ class ResponseConfig:
                 self.forced_throttle = True
 
     def _resolve_file_path(self, wrapper, request_type):
-        global SHOULD_THROTTLE
         if self.json_path is None:
             if self.forced_throttle:
                 # force the throttle to happend, instead of just 50%.
@@ -85,16 +82,6 @@ class ResponseConfig:
                     response_file, "not exist, using the default response")
                 response_file = os.path.join(
                     base_dir, request_type.name, f"default.json")
-            if "throttle" in response_file:
-                # We throttle the request half the time to make sure it succeeds after a retry
-                if SHOULD_THROTTLE is False:
-                    wrapper.info("Skipping throttling")
-                    response_file = os.path.join(
-                        base_dir, request_type.name, f"default.json")
-                else:
-                    wrapper.info("Throttling")
-                # Flip the flag
-                SHOULD_THROTTLE = not SHOULD_THROTTLE
             self.json_path = response_file
 
     def resolve_response(self, wrapper, request_type, chunked=False, head_request=False):
@@ -381,16 +368,6 @@ async def send_mock_s3_response(wrapper, request_type, path, generate_body=False
         wrapper.info(response_file, "not exist, using the default response")
         response_file = os.path.join(
             base_dir, request_type.name, f"default.json")
-    if "throttle" in response_file:
-        # We throttle the request half the time to make sure it succeeds after a retry
-        if wrapper.should_throttle is False:
-            wrapper.info("Skipping throttling")
-            response_file = os.path.join(
-                base_dir, request_type.name, f"default.json")
-        else:
-            wrapper.info("Throttling")
-        # Flip the flag
-        wrapper.should_throttle = not wrapper.should_throttle
     await send_response_from_json(wrapper, response_file, generate_body=generate_body, generate_body_size=generate_body_size, head_request=head_request)
 
 

--- a/tests/s3_cancel_tests.c
+++ b/tests/s3_cancel_tests.c
@@ -232,8 +232,9 @@ static int s3_cancel_test_helper_ex(
 
         struct aws_s3_meta_request_test_results meta_request_test_results;
         aws_s3_meta_request_test_results_init(&meta_request_test_results, allocator);
-        struct aws_s3_file_io_options fio_opts = {
-            .should_stream = file_streaming,
+        struct aws_s3_file_io_option fio_opts = {
+            .streaming_upload = file_streaming,
+            .direct_io = true,
         };
 
         struct aws_s3_tester_meta_request_options options = {

--- a/tests/s3_cancel_tests.c
+++ b/tests/s3_cancel_tests.c
@@ -232,8 +232,8 @@ static int s3_cancel_test_helper_ex(
 
         struct aws_s3_meta_request_test_results meta_request_test_results;
         aws_s3_meta_request_test_results_init(&meta_request_test_results, allocator);
-        struct aws_s3_file_io_option fio_opts = {
-            .streaming_upload = file_streaming,
+        struct aws_s3_file_io_options fio_opts = {
+            .should_stream = file_streaming,
             .direct_io = true,
         };
 

--- a/tests/s3_data_plane_tests.c
+++ b/tests/s3_data_plane_tests.c
@@ -2173,6 +2173,7 @@ static int s_test_s3_put_object_multiple_helper(
     /* Configure file I/O options for streaming upload */
     struct aws_s3_file_io_options fio_opts = {
         .should_stream = enable_streaming,
+        .direct_io = true,
     };
     size_t content_length = MB_TO_BYTES(10);
 
@@ -4815,6 +4816,7 @@ static int s_test_s3_round_trip_with_filepath_helper(
     /* Configure file I/O options for streaming upload */
     struct aws_s3_file_io_options fio_opts = {
         .should_stream = streaming,
+        .direct_io = true,
     };
 
     struct aws_s3_tester_meta_request_options put_options = {
@@ -5011,6 +5013,7 @@ static int s_test_s3_mpu_with_filepath_streaming_dont_support_parts_checksum_via
     AWS_ZERO_STRUCT(path_buf); /* Configure file I/O options for streaming upload */
     struct aws_s3_file_io_options fio_opts = {
         .should_stream = true,
+        .direct_io = true,
     };
 
     ASSERT_SUCCESS(aws_s3_tester_upload_file_path_init(

--- a/tests/s3_mock_server_tests.c
+++ b/tests/s3_mock_server_tests.c
@@ -438,7 +438,6 @@ TEST_CASE(multipart_upload_with_network_interface_names_mock_server) {
 static void s_after_prepare_upload_part_finish(struct aws_s3_request *request, struct aws_http_message *message) {
     (void)message;
     if (request->num_times_prepared == 0 && message != NULL) {
-        aws_http_message_add_header(message, before_finish_header);
         struct aws_http_header throttle_header = {
             .name = aws_byte_cursor_from_c_str("force_throttle"),
             .value = aws_byte_cursor_from_c_str("true"),

--- a/tests/s3_mock_server_tests.c
+++ b/tests/s3_mock_server_tests.c
@@ -490,7 +490,7 @@ TEST_CASE(multipart_upload_checksum_with_retry_before_finish_mock_server) {
     patched_client_vtable->after_prepare_upload_part_finish =
         s_after_prepare_upload_part_finish_retry_before_finish_sending;
 
-    struct aws_byte_cursor object_path = aws_byte_cursor_from_c_str("/throttle");
+    struct aws_byte_cursor object_path = aws_byte_cursor_from_c_str("/default");
     {
         /* 1. Trailer checksum */
         struct aws_s3_tester_meta_request_options put_options = {
@@ -549,7 +549,7 @@ TEST_CASE(multipart_upload_checksum_with_retry_mock_server) {
     struct aws_s3_client_vtable *patched_client_vtable = aws_s3_tester_patch_client_vtable(&tester, client, NULL);
     patched_client_vtable->after_prepare_upload_part_finish = s_after_prepare_upload_part_finish;
 
-    struct aws_byte_cursor object_path = aws_byte_cursor_from_c_str("/throttle");
+    struct aws_byte_cursor object_path = aws_byte_cursor_from_c_str("/default");
     {
         /* 1. Trailer checksum */
         struct aws_s3_tester_meta_request_options put_options = {
@@ -635,7 +635,7 @@ TEST_CASE(multipart_upload_checksum_fio_with_retry_mock_server) {
         .should_stream = true,
         .direct_io = true,
     };
-    struct aws_byte_cursor object_path = aws_byte_cursor_from_c_str("/throttle");
+    struct aws_byte_cursor object_path = aws_byte_cursor_from_c_str("/default");
 
     /* retry with streaming upload. */
     struct aws_s3_tester_meta_request_options put_options = {

--- a/tests/s3_parallel_read_stream_test.c
+++ b/tests/s3_parallel_read_stream_test.c
@@ -184,7 +184,7 @@ TEST_CASE(parallel_read_stream_from_file_sanity_test) {
     ASSERT_NOT_NULL(reading_elg);
 
     struct aws_parallel_input_stream *parallel_read_stream =
-        aws_parallel_input_stream_new_from_file(allocator, path_cursor, reading_elg);
+        aws_parallel_input_stream_new_from_file(allocator, path_cursor, reading_elg, false /*direct_io*/);
     ASSERT_NOT_NULL(parallel_read_stream);
 
     aws_parallel_input_stream_acquire(parallel_read_stream);
@@ -286,7 +286,7 @@ TEST_CASE(parallel_read_stream_from_large_file_test) {
     struct aws_byte_cursor path_cursor = aws_byte_cursor_from_c_str(file_path);
 
     struct aws_parallel_input_stream *parallel_read_stream =
-        aws_parallel_input_stream_new_from_file(allocator, path_cursor, reading_elg);
+        aws_parallel_input_stream_new_from_file(allocator, path_cursor, reading_elg, false /*direct_io*/);
     ASSERT_NOT_NULL(parallel_read_stream);
 
     {
@@ -385,7 +385,7 @@ static int s_part_streaming_test_setup(
 
     struct aws_byte_cursor path_cursor = aws_byte_cursor_from_c_str(file_path);
     fixture->parallel_read_stream =
-        aws_parallel_input_stream_new_from_file(allocator, path_cursor, fixture->reading_elg);
+        aws_parallel_input_stream_new_from_file(allocator, path_cursor, fixture->reading_elg, false /*direct_io*/);
     ASSERT_NOT_NULL(fixture->parallel_read_stream);
 
     fixture->buffer_pool = aws_s3_default_buffer_pool_new(

--- a/tests/s3_parallel_read_stream_test.c
+++ b/tests/s3_parallel_read_stream_test.c
@@ -534,7 +534,7 @@ TEST_CASE(part_streaming_stream_from_large_file_test) {
     size_t file_length = MB_TO_BYTES(100);
 
     ASSERT_SUCCESS(s_part_streaming_test_setup(
-        allocator, &fixture, "s3_part_streaming_stream_read_large.txt", file_length, KB_TO_BYTES(16)));
+        allocator, &fixture, "s3_part_streaming_stream_read_large.txt", file_length, KB_TO_BYTES(64)));
     /* Test reading from unaligned offset */
     struct aws_input_stream *part_streaming_stream = aws_part_streaming_input_stream_new(
         allocator, fixture.parallel_read_stream, fixture.ticket, 0, file_length, true);
@@ -753,7 +753,7 @@ TEST_CASE(part_streaming_stream_file_deleted_during_read_test) {
     size_t file_length = MB_TO_BYTES(1);
 
     ASSERT_SUCCESS(s_part_streaming_test_setup(
-        allocator, &fixture, "s3_part_streaming_stream_delete_test.txt", file_length, KB_TO_BYTES(16)));
+        allocator, &fixture, "s3_part_streaming_stream_delete_test.txt", file_length, KB_TO_BYTES(64)));
 
     /* Create the part streaming stream */
     struct aws_input_stream *part_streaming_stream = aws_part_streaming_input_stream_new(

--- a/tests/s3_test_parallel_stream.c
+++ b/tests/s3_test_parallel_stream.c
@@ -61,9 +61,11 @@ static struct aws_parallel_input_stream_vtable s_parallel_input_stream_from_file
 struct aws_parallel_input_stream *aws_parallel_input_stream_new_from_file_failure_tester(
     struct aws_allocator *allocator,
     struct aws_byte_cursor file_name,
-    struct aws_event_loop_group *reading_elg) {
+    struct aws_event_loop_group *reading_elg,
+    bool direct_io_read) {
     (void)file_name;
     (void)reading_elg;
+    (void)direct_io_read;
 
     struct aws_parallel_input_stream_from_file_failure_impl *impl =
         aws_mem_calloc(allocator, 1, sizeof(struct aws_parallel_input_stream_from_file_failure_impl));

--- a/tests/s3_tester.h
+++ b/tests/s3_tester.h
@@ -495,7 +495,8 @@ int aws_s3_tester_check_s3express_creds_for_default_mock_response(struct aws_cre
 struct aws_parallel_input_stream *aws_parallel_input_stream_new_from_file_failure_tester(
     struct aws_allocator *allocator,
     struct aws_byte_cursor file_name,
-    struct aws_event_loop_group *reading_elg);
+    struct aws_event_loop_group *reading_elg,
+    bool direct_io_read);
 
 extern struct aws_s3_client_vtable g_aws_s3_client_mock_vtable;
 


### PR DESCRIPTION
*Issue #, if available:*

- Add direct IO support for uploading
- Based on https://github.com/awslabs/aws-c-common/pull/1217

*Description of changes:*
- TODO: direct IO support for downloading. But, there is a workaround for download that customer can implement their own direct IO as we streaming the bytes to down stream. So, it's currently a low priority.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
