### PR TITLE
update the default behaviors on the fio options

### DIFF
--- a/include/aws/s3/s3_client.h
+++ b/include/aws/s3/s3_client.h
@@ -315,14 +315,16 @@ enum aws_s3_recv_file_options {
     AWS_S3_RECV_FILE_WRITE_TO_POSITION,
 };
 
-/* Controls how client performance file I/O operations. Only applies to the file based workload. */
+/**
+ * WARNING: experimental/unstable:
+ * Controls how client performance file I/O operations. Only applies to the file based workload.
+ **/
 struct aws_s3_file_io_options {
     /**
      * Skip buffering the part in memory before sending the request.
-     * If set, set the `disk_throughput_gbps` to be reasonable align with the available disk throughput.
-     * Otherwise, the transfer may fail with connection starvation.
      *
-     * Default to false.
+     * Default to false on small objects, and true when the object size exceed a certain threshold
+     *`g_streaming_object_size_threshold`.
      **/
     bool should_stream;
 
@@ -330,12 +332,11 @@ struct aws_s3_file_io_options {
      * The estimated disk throughput. Only be applied when `streaming_upload` is true.
      * in gigabits per second (Gbps).
      *
-     * When doing upload with streaming, it's important to set the disk throughput to prevent the connection starvation.
      * Notes: There are possibilities that cannot reach the all available disk throughput:
      * 1. Disk is busy with other applications
      * 2. OS Cache may cap the throughput, use `direct_io` to get around this.
      *
-     * Note: When `streaming_upload` is true, this default to 10 Gbps.
+     * Default to throughput_target_gbps.
      **/
     double disk_throughput_gbps;
 

--- a/source/s3_meta_request.c
+++ b/source/s3_meta_request.c
@@ -194,7 +194,7 @@ int aws_s3_meta_request_init_base(
 
     if (meta_request->fio_opts.should_stream && meta_request->fio_opts.disk_throughput_gbps == 0) {
         /* If disk throughput is not set, set it to the default. */
-        meta_request->fio_opts.disk_throughput_gbps = g_default_throughput_target_gbps;
+        meta_request->fio_opts.disk_throughput_gbps = client->throughput_target_gbps;
     }
 
     /* Set up reference count. */

--- a/source/s3_util.c
+++ b/source/s3_util.c
@@ -64,10 +64,31 @@ const struct aws_byte_cursor g_user_agent_header_unknown = AWS_BYTE_CUR_INIT_FRO
 
 const uint32_t g_s3_max_num_upload_parts = 10000;
 const size_t g_s3_min_upload_part_size = MB_TO_BYTES(5);
-const size_t g_streaming_buffer_size = MB_TO_BYTES(8);
+
 const double g_default_throughput_target_gbps = 10.0;
-/* TODO: disable this threshold until we have a better option for threshold */
-const uint64_t g_streaming_object_size_threshold = UINT64_MAX;
+
+/**
+ * Streaming buffer size selection based on experimental results on EBS:
+ *
+ * - Too small buffer sizes (e.g., 16KiB) impact disk read performance,
+ *   achieving only 6.73 Gbps throughput from EBS.
+ * - Too large buffer sizes cause network connections to starve more easily
+ *   when disk reads cannot provide data fast enough.
+ * - 1MiB buffer size provides optimal balance: sufficient disk read throughput
+ *   while maintaining reasonable retry rates due to connection starvation.
+ */
+const size_t g_streaming_buffer_size = MB_TO_BYTES(1);
+
+/**
+ * The streaming approach reduces memory consumption without introducing unexpected errors
+ * or performance degradation.
+ *
+ * We start streaming for objects larger than 1TiB, with plans to lower this threshold in future iterations.
+ *
+ * The 1TiB threshold was chosen to minimize the blast radius of this behavioral change
+ * while still providing meaningful memory usage improvements for large objects.
+ */
+const uint64_t g_streaming_object_size_threshold = TB_TO_BYTES(1);
 
 void copy_http_headers(const struct aws_http_headers *src, struct aws_http_headers *dest) {
     AWS_PRECONDITION(src);


### PR DESCRIPTION
*Issue #, if available:*
- behavior breaking change:
  - `aws_s3_file_io_options` is experimental, the default behavior is likely to be change in the future.
  - Changing the default behavior based on more testing did and found that 1MiB is much more reasonable comparing to 8MiB chunk to read from the file.
  - With smaller chunks to read from the file, it's much less likely to hit the connection starvation problem that we were worrying about, so relax the threshold to enable the streaming by default. And default the `disk_throughput_gbps` to the `throughput_target_gbps` on the client.
 
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
