### PR TITLE
builder -> v0.9.91 and clang-latest

### DIFF
--- a/.builder/actions/mock_server_setup.py
+++ b/.builder/actions/mock_server_setup.py
@@ -24,6 +24,8 @@ class MockServerSetup(Builder.Action):
 
         self.env = env
         python_path = sys.executable
+        # ensure pip is available
+        self.env.shell.exec(python_path, '-m', 'ensurepip', '--upgrade', check=False)
         # install dependency for mock server
         self.env.shell.exec(python_path,
                             '-m', 'pip', 'install', 'h11', 'trio', 'proxy.py', check=True)

--- a/.builder/actions/mock_server_setup.py
+++ b/.builder/actions/mock_server_setup.py
@@ -17,15 +17,38 @@ class MockServerSetup(Builder.Action):
     This action should be run in the 'pre_build_steps' or 'build_steps' stage.
     """
 
+    def _find_python_with_pip(self):
+        """
+        Find a Python executable that has pip.
+        The builder may run under a stripped system Python (e.g. Python 3.6 on Ubuntu 18)
+        that has no pip or ensurepip.
+        """
+        import shutil
+
+        # Candidates in preference order: newer Pythons first, then sys.executable
+        candidates = ['python3.12', 'python3.11', 'python3.10', 'python3.9', 'python3.8', sys.executable]
+
+        for candidate in candidates:
+            python = shutil.which(candidate)
+            if python is None:
+                continue
+            result = subprocess.run([python, '-m', 'pip', '--version'],
+                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            if result.returncode == 0:
+                print("Found Python with pip: {}".format(python))
+                return python
+
+        # No Python with pip found; return sys.executable and let pip install fail with a clear error
+        return sys.executable
+
     def run(self, env):
         if not env.project.needs_tests(env):
             print("Skipping mock server setup because tests disabled for project")
             return
 
         self.env = env
-        python_path = sys.executable
-        # ensure pip is available
-        self.env.shell.exec(python_path, '-m', 'ensurepip', '--upgrade', check=False)
+        python_path = self._find_python_with_pip()
+
         # install dependency for mock server
         self.env.shell.exec(python_path,
                             '-m', 'pip', 'install', 'h11', 'trio', 'proxy.py', check=True)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BUILDER_VERSION: v0.9.74
+  BUILDER_VERSION: v0.9.91
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-s3
@@ -62,6 +62,7 @@ jobs:
           - name: clang-11
           - name: clang-15
           - name: clang-17
+          - name: clang-latest
           - name: gcc-4.8
           - name: gcc-5
           - name: gcc-6


### PR DESCRIPTION
Update builder version to v0.9.91.
Add clang-latest to linux-compiler-compat matrix.

When running mock_server_setup.py don't rely strictly on `sys.executable` and instead first try to find a python that has pip available.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
