### PR TITLE
builder -> v0.9.92 and clang-latest

### DIFF
--- a/.builder/actions/mock_server_setup.py
+++ b/.builder/actions/mock_server_setup.py
@@ -24,6 +24,8 @@ class MockServerSetup(Builder.Action):
 
         self.env = env
         python_path = sys.executable
+        # ensure pip is available
+        self.env.shell.exec(python_path, '-m', 'ensurepip', '--upgrade', check=False)
         # install dependency for mock server
         self.env.shell.exec(python_path,
                             '-m', 'pip', 'install', 'h11', 'trio', 'proxy.py', check=True)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BUILDER_VERSION: v0.9.74
+  BUILDER_VERSION: v0.9.92
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-s3
@@ -62,6 +62,7 @@ jobs:
           - name: clang-11
           - name: clang-15
           - name: clang-17
+          - name: clang-latest
           - name: gcc-4.8
           - name: gcc-5
           - name: gcc-6


### PR DESCRIPTION
Update builder version to v0.9.92.
Add clang-latest to linux-compiler-compat matrix.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
