### PR TITLE
fix copy object mpu

### DIFF
--- a/include/aws/s3/private/s3_request_messages.h
+++ b/include/aws/s3/private/s3_request_messages.h
@@ -122,7 +122,22 @@ struct aws_http_message *aws_s3_upload_part_copy_message_new(
 
 /* Create an HTTP request for an S3 Complete-Multipart-Upload request. Creates the necessary XML payload using the
  * passed in array list of `struct aws_s3_mpu_part_info *`. Buffer passed in will be used to store
- * said XML payload, which will be used as the body. */
+ * said XML payload, which will be used as the body. The x-amz-mp-object-size header is taken from object_size; pass
+ * the known total object size, or 0 to omit the header (e.g. a streaming upload of unknown length). */
+AWS_S3_API
+struct aws_http_message *aws_s3_complete_multipart_message_with_object_size_new(
+    struct aws_allocator *allocator,
+    struct aws_http_message *base_message,
+    struct aws_byte_buf *body_buffer,
+    const struct aws_string *upload_id,
+    const struct aws_array_list *parts,
+    const struct aws_s3_meta_request_checksum_config_storage *checksum_config,
+    uint64_t object_size);
+
+/* Convenience wrapper over aws_s3_complete_multipart_message_with_object_size_new() that derives the object size from
+ * base_message's Content-Length (0 if absent/unparseable). Suitable for the multipart upload path, where the base PUT
+ * carries the full object length; the copy path must call the _with_object_size_ variant directly because its base
+ * CopyObject is bodyless. */
 AWS_S3_API
 struct aws_http_message *aws_s3_complete_multipart_message_new(
     struct aws_allocator *allocator,

--- a/source/s3_copy_object.c
+++ b/source/s3_copy_object.c
@@ -489,14 +489,17 @@ static struct aws_future_void *s_s3_copy_object_prepare_request(struct aws_s3_re
             aws_byte_buf_reset(&request->request_body, false);
 
             /* Build the message to complete our multipart upload, which includes a payload describing all of our
-             * completed parts. */
-            message = aws_s3_complete_multipart_message_new(
+             * completed parts. The object size (discovered via the HEAD on the source) is passed explicitly so the
+             * x-amz-mp-object-size header matches what S3 computes from the copied parts; the base CopyObject request
+             * is bodyless, so its Content-Length cannot be used as the source of that value. */
+            message = aws_s3_complete_multipart_message_with_object_size_new(
                 meta_request->allocator,
                 meta_request->initial_request_message,
                 &request->request_body,
                 copy_object->upload_id,
                 &copy_object->synced_data.part_list,
-                NULL);
+                NULL,
+                copy_object->synced_data.content_length);
 
             break;
         }

--- a/source/s3_request_messages.c
+++ b/source/s3_request_messages.c
@@ -678,13 +678,14 @@ static const struct aws_byte_cursor s_open_end_bracket = AWS_BYTE_CUR_INIT_FROM_
 static const struct aws_byte_cursor s_close_bracket = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(">");
 static const struct aws_byte_cursor s_close_bracket_new_line = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(">\n");
 /* Create a complete-multipart message, which includes an XML payload of all completed parts. */
-struct aws_http_message *aws_s3_complete_multipart_message_new(
+struct aws_http_message *aws_s3_complete_multipart_message_with_object_size_new(
     struct aws_allocator *allocator,
     struct aws_http_message *base_message,
     struct aws_byte_buf *body_buffer,
     const struct aws_string *upload_id,
     const struct aws_array_list *parts,
-    const struct aws_s3_meta_request_checksum_config_storage *checksum_config) {
+    const struct aws_s3_meta_request_checksum_config_storage *checksum_config,
+    uint64_t object_size) {
     AWS_PRECONDITION(allocator);
     AWS_PRECONDITION(base_message);
     AWS_PRECONDITION(body_buffer);
@@ -696,8 +697,6 @@ struct aws_http_message *aws_s3_complete_multipart_message_new(
     struct aws_http_message *message = NULL;
     bool set_checksums =
         checksum_config && (checksum_config->location != AWS_SCL_NONE || checksum_config->has_full_object_checksum);
-    const struct aws_http_headers *initial_message_headers = aws_http_message_get_headers(base_message);
-    AWS_ASSERT(initial_message_headers);
     if (set_checksums) {
         mpu_algorithm_checksum_name =
             aws_get_completed_part_name_from_checksum_algorithm(checksum_config->checksum_algorithm);
@@ -750,11 +749,15 @@ struct aws_http_message *aws_s3_complete_multipart_message_new(
             goto error_clean_up;
         }
     }
-    struct aws_byte_cursor content_length_cursor;
-    if (aws_http_headers_get(initial_message_headers, g_content_length_header_name, &content_length_cursor) ==
-        AWS_OP_SUCCESS) {
-        /* Set content-length from base message as x-amz-mp-object-size. */
-        if (aws_http_headers_set(headers, aws_byte_cursor_from_c_str("x-amz-mp-object-size"), content_length_cursor)) {
+    /* Send the total object size as x-amz-mp-object-size so S3 can validate the assembled object. object_size of 0
+     * means "unknown" (e.g. a streaming upload of unknown length); in that case the header is omitted, matching the
+     * prior behavior of skipping it when the base message had no Content-Length. */
+    if (object_size > 0) {
+        char object_size_buffer[32];
+        int object_size_len = snprintf(object_size_buffer, sizeof(object_size_buffer), "%" PRIu64, object_size);
+        struct aws_byte_cursor object_size_cursor =
+            aws_byte_cursor_from_array(object_size_buffer, (size_t)object_size_len);
+        if (aws_http_headers_set(headers, aws_byte_cursor_from_c_str("x-amz-mp-object-size"), object_size_cursor)) {
             goto error_clean_up;
         }
     }
@@ -853,6 +856,32 @@ error_clean_up:
     }
 
     return NULL;
+}
+
+struct aws_http_message *aws_s3_complete_multipart_message_new(
+    struct aws_allocator *allocator,
+    struct aws_http_message *base_message,
+    struct aws_byte_buf *body_buffer,
+    const struct aws_string *upload_id,
+    const struct aws_array_list *parts,
+    const struct aws_s3_meta_request_checksum_config_storage *checksum_config) {
+
+    /* Derive the object size from the base message's Content-Length, as the multipart upload path expects. A missing
+     * or unparseable Content-Length (e.g. a streaming upload of unknown length) yields 0, which tells the delegate to
+     * omit the x-amz-mp-object-size header. */
+    uint64_t object_size = 0;
+    struct aws_byte_cursor content_length_cursor;
+    const struct aws_http_headers *initial_message_headers = aws_http_message_get_headers(base_message);
+    if (initial_message_headers != NULL &&
+        aws_http_headers_get(initial_message_headers, g_content_length_header_name, &content_length_cursor) ==
+            AWS_OP_SUCCESS) {
+        if (aws_byte_cursor_utf8_parse_u64(content_length_cursor, &object_size)) {
+            object_size = 0;
+        }
+    }
+
+    return aws_s3_complete_multipart_message_with_object_size_new(
+        allocator, base_message, body_buffer, upload_id, parts, checksum_config, object_size);
 }
 
 struct aws_http_message *aws_s3_abort_multipart_upload_message_new(

--- a/tests/s3_tester.c
+++ b/tests/s3_tester.c
@@ -2371,6 +2371,15 @@ static struct aws_http_message *s_copy_object_request_new(
         goto error_clean_up_message;
     }
 
+    /* Copy Object request has a content length of 0 */
+    struct aws_http_header content_length_header = {
+        .name = g_content_length_header_name,
+        .value = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("0"),
+    };
+    if (aws_http_message_add_header(message, content_length_header)) {
+        goto error_clean_up_message;
+    }
+
     struct aws_byte_buf copy_source_value_encoded;
     aws_byte_buf_init(&copy_source_value_encoded, allocator, 1024);
     aws_byte_buf_append_encoding_uri_path(&copy_source_value_encoded, &x_amz_source);


### PR DESCRIPTION
*Description of changes:*

Fixes copy object MPU.

When https://github.com/awslabs/aws-c-s3/commit/337155f6c07d39e61234e705ed6e58c31d4841eb was merged extending checksum functionality, full object checksum on the MPU path broke copy object when a content-length of 0 was included in the request. since copy object has a body length of 0 it was being included as `x-amz-mp-object-size` during the mutipart upload causing mismatches.

reproduction:

```c
#include <aws/auth/credentials.h>
#include <aws/common/condition_variable.h>
#include <aws/common/mutex.h>
#include <aws/http/request_response.h>
#include <aws/io/channel_bootstrap.h>
#include <aws/io/event_loop.h>
#include <aws/io/host_resolver.h>
#include <aws/s3/s3.h>
#include <aws/s3/s3_client.h>

#include <stdio.h>

static const struct aws_byte_cursor REGION = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("us-east-1");

struct completion {
    struct aws_mutex mutex;
    struct aws_condition_variable cvar;
    bool done;
    int error_code;
};

static bool s_is_done(void *arg) {
    return ((struct completion *)arg)->done;
}

static void s_on_finish(
    struct aws_s3_meta_request *meta_request,
    const struct aws_s3_meta_request_result *result,
    void *user_data) {
    (void)meta_request;
    struct completion *c = user_data;

    if (result->error_code == AWS_ERROR_SUCCESS) {
        printf("CopyObject SUCCEEDED (status %d)\n", result->response_status);
    } else {
        fprintf(stderr, "CopyObject FAILED: %s (status %d)\n",
            aws_error_str(result->error_code), result->response_status);
        if (result->error_response_body != NULL && result->error_response_body->len > 0) {
            fprintf(stderr, "%.*s\n",
                (int)result->error_response_body->len, result->error_response_body->buffer);
        }
    }

    aws_mutex_lock(&c->mutex);
    c->error_code = result->error_code;
    c->done = true;
    aws_mutex_unlock(&c->mutex);
    aws_condition_variable_notify_one(&c->cvar);
}

int main(void) {
    struct aws_allocator *allocator = aws_default_allocator();
    aws_s3_library_init(allocator);

    struct aws_event_loop_group *el_group = aws_event_loop_group_new_default(allocator, 0, NULL);
    struct aws_host_resolver_default_options resolver_options = {.el_group = el_group, .max_entries = 8};
    struct aws_host_resolver *resolver = aws_host_resolver_new_default(allocator, &resolver_options);
    struct aws_client_bootstrap_options bootstrap_options = {.event_loop_group = el_group, .host_resolver = resolver};
    struct aws_client_bootstrap *bootstrap = aws_client_bootstrap_new(allocator, &bootstrap_options);

    struct aws_credentials_provider_chain_default_options creds_options = {.bootstrap = bootstrap};
    struct aws_credentials_provider *creds = aws_credentials_provider_new_chain_default(allocator, &creds_options);

    struct aws_signing_config_aws signing_config = {0};
    aws_s3_init_default_signing_config(&signing_config, REGION, creds);

    struct aws_s3_client_config client_config = {
        .region = REGION,
        .client_bootstrap = bootstrap,
        .signing_config = &signing_config,
    };
    struct aws_s3_client *client = aws_s3_client_new(allocator, &client_config);

    struct aws_http_message *message = aws_http_message_new_request(allocator);
    struct aws_http_header host = {
        .name = aws_byte_cursor_from_c_str("host"),
        .value = aws_byte_cursor_from_c_str("your_bucket.s3.us-east-1.amazonaws.com"),
    };
    struct aws_http_header content_length = {
        .name = aws_byte_cursor_from_c_str("content-length"),
        .value = aws_byte_cursor_from_c_str("0"),
    };
    struct aws_http_header copy_source = {
        .name = aws_byte_cursor_from_c_str("x-amz-copy-source"),
        .value = aws_byte_cursor_from_c_str("your_bucket/large-source-object"),
    };
    aws_http_message_set_request_method(message, aws_http_method_put);
    aws_http_message_set_request_path(message, aws_byte_cursor_from_c_str("/large-dest-object"));
    aws_http_message_add_header(message, host);
    aws_http_message_add_header(message, content_length);
    aws_http_message_add_header(message, copy_source);

    struct completion c = {0};
    aws_mutex_init(&c.mutex);
    aws_condition_variable_init(&c.cvar);

    struct aws_s3_meta_request_options options = {
        .type = AWS_S3_META_REQUEST_TYPE_COPY_OBJECT,
        .message = message,
        .copy_source_uri = aws_byte_cursor_from_c_str("sbiscigl/large-source-object"),
        .finish_callback = s_on_finish,
        .user_data = &c,
    };

    struct aws_s3_meta_request *meta_request = aws_s3_client_make_meta_request(client, &options);
    if (meta_request == NULL) {
        fprintf(stderr, "make_meta_request failed: %s\n", aws_error_str(aws_last_error()));
        return 1;
    }

    aws_mutex_lock(&c.mutex);
    aws_condition_variable_wait_pred(&c.cvar, &c.mutex, s_is_done, &c);
    aws_mutex_unlock(&c.mutex);

    aws_s3_meta_request_release(meta_request);
    aws_http_message_release(message);
    aws_s3_client_release(client);
    aws_credentials_provider_release(creds);
    aws_client_bootstrap_release(bootstrap);
    aws_host_resolver_release(resolver);
    aws_event_loop_group_release(el_group);
    aws_condition_variable_clean_up(&c.cvar);
    aws_mutex_clean_up(&c.mutex);
    aws_s3_library_clean_up();

    return c.error_code == AWS_ERROR_SUCCESS ? 0 : 1;
}
```

would result in
```
CopyObject FAILED: Invalid response status from request (status 400)
<Error><Code>InvalidRequest</Code><Message>The provided 'x-amz-mp-object-size' header value 0 does not match what was computed: 2147483648</Message><RequestId>....</RequestId><HostId>...</HostId></Error>
```
this changes to pass the value from the head object operation to the request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
