### PR TITLE
Fix auto-ranged GET fallback for opaque ETags

### DIFF
--- a/source/s3_auto_ranged_get.c
+++ b/source/s3_auto_ranged_get.c
@@ -842,7 +842,6 @@ static void s_s3_auto_ranged_get_request_finished(
                     "id=%p Failed to parse ETags, fallback to default part size.",
                     (void *)meta_request);
                 auto_ranged_get->estimated_object_stored_part_size = g_default_part_size_fallback;
-                goto update_synced_data;
             }
             auto_ranged_get->num_stored_parts = num_parts;
         }


### PR DESCRIPTION
*Issue #, if available:* No open issue

*Description of changes:* AWS S3 ETags normally follow the format expected by `aws_s3_extract_parts_from_etag()`, so auto-ranged GETs work as expected against AWS S3.
However, ETags are opaque identifiers, and S3-compatible storage providers do not necessarily use AWS’s single-part or multipart ETag format. For example, GCP-backed buckets may return ETags such as: `-CNq51frhmpUDEAE=`
This value cannot be parsed to determine the number of stored parts. 
The existing code detects this parsing failure and sets `estimated_object_stored_part_size` to the default fallback value. However, it then jumps directly to synchronized-state handling, skipping the remaining successful object-discovery logic. As a result, an otherwise valid auto-ranged GET can fail or fail to record the discovered object metadata.
This change removes the premature `goto`, allowing execution to continue with the existing default-part-size fallback.
AWS S3 behavior remains unchanged for recognized ETag formats, while auto-ranged GETs now interoperate correctly with GCP buckets and other S3-compatible storage providers that return opaque ETags.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
